### PR TITLE
feat: add descriptive body to release tracker issues

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -328,10 +328,11 @@ func runReleaseStartWithDeps(cmd *cobra.Command, opts *releaseStartOptions, cfg 
 
 	// Use branch name for tracker title and Release field
 	title := fmt.Sprintf("Release: %s", opts.branch)
+	body := generateReleaseTrackerTemplate(opts.branch)
 
 	// Create tracker issue with release label
 	labels := []string{"release"}
-	issue, err := client.CreateIssue(owner, repo, title, "", labels)
+	issue, err := client.CreateIssue(owner, repo, title, body, labels)
 	if err != nil {
 		return fmt.Errorf("failed to create tracker issue: %w", err)
 	}
@@ -605,6 +606,35 @@ func generateReleaseTrackerBody(issues []api.Issue) string {
 		sb.WriteString(fmt.Sprintf("- #%d %s\n", issue.Number, issue.Title))
 	}
 	return sb.String()
+}
+
+// generateReleaseTrackerTemplate generates the initial body template for a release tracker issue
+func generateReleaseTrackerTemplate(branchName string) string {
+	return fmt.Sprintf(`> **Release Tracker Issue**
+>
+> This issue tracks the release %s. It is managed by gh pmu release commands.
+>
+> **Do not manually:**
+> - Close or reopen this issue
+> - Change the title
+> - Remove the %s label
+
+## Commands
+
+- %s - Add issues to this release
+- %s - Remove issues from this release
+- %s - Close this release
+
+## Issues in this release
+
+_Issues are tracked via the Release field in the project._
+`,
+		"`"+branchName+"`",
+		"`release`",
+		"`gh pmu release add <issue>`",
+		"`gh pmu release remove <issue>`",
+		"`gh pmu release close "+branchName+"`",
+	)
 }
 
 // runReleaseCloseWithDeps is the testable entry point for release close


### PR DESCRIPTION
## Summary

When `gh pmu release start` creates a tracker issue, it now includes a descriptive body explaining its purpose and warning against manual modification.

## Changes

Added `generateReleaseTrackerTemplate()` function that generates:

```markdown
> **Release Tracker Issue**
>
> This issue tracks the release `release/v1.0.0`. It is managed by gh pmu release commands.
>
> **Do not manually:**
> - Close or reopen this issue
> - Change the title
> - Remove the `release` label

## Commands

- `gh pmu release add <issue>` - Add issues to this release
- `gh pmu release remove <issue>` - Remove issues from this release
- `gh pmu release close release/v1.0.0` - Close this release

## Issues in this release

_Issues are tracked via the Release field in the project._
```

## Test plan

- [x] All release tests pass
- [x] Build succeeds
- [ ] Manual test: create release and verify body appears

Fixes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)