### PR TITLE
fix: add fetch-depth for Codecov diff coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 2` to test job checkout for Codecov PR diff coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)