### PR TITLE
fix: add mutex to prevent data race in mock handler

### DIFF
--- a/cmd/wrapper_test.go
+++ b/cmd/wrapper_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rubrical-studios/gh-pmu/internal/api"
@@ -22,6 +23,8 @@ type mockGraphQLHandler struct {
 	defaultResponse interface{}
 	// Track requests for assertions
 	requests []graphQLRequest
+	// Mutex to protect concurrent access to requests
+	mu sync.Mutex
 }
 
 type graphQLRequest struct {
@@ -43,7 +46,9 @@ func (h *mockGraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
+	h.mu.Lock()
 	h.requests = append(h.requests, req)
+	h.mu.Unlock()
 
 	// Find matching response based on query content
 	var response interface{}


### PR DESCRIPTION
## Summary
- Add sync.Mutex to mockGraphQLHandler to protect concurrent access to the requests slice

## Problem
The CI test run on main failed with a data race in `TestRunView_LoadsConfig`:
```
WARNING: DATA RACE
Read at 0x00c000289b78 by goroutine 1108:
  github.com/rubrical-studios/gh-pmu/cmd.(*mockGraphQLHandler).ServeHTTP()
      cmd/wrapper_test.go:46 +0x1d3
```

## Test plan
- [x] `go test -race ./cmd/...` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)