### PR TITLE
fix: GraphQL input types and release close improvements (#425, #426, #427)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -496,8 +496,8 @@ func openEditorForBody(initialContent string) (string, error) {
 		}
 	}
 
-	// Create a temporary file
-	tmpfile, err := os.CreateTemp("", "gh-pmu-issue-*.md")
+	// Create a temporary file in project tmp directory
+	tmpfile, err := config.CreateTempFile("gh-pmu-issue-*.md")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -961,8 +961,8 @@ func renderDetailedHistoryScreen(commits []CommitInfo, targetPath string) {
 func openHistoryInBrowser(commits []CommitInfo, targetPath, repoOwner, repoName string) error {
 	htmlContent := generateHistoryHTML(commits, targetPath, repoOwner, repoName)
 
-	// Create temp file
-	tmpFile, err := os.CreateTemp("", "gh-pmu-history-*.html")
+	// Create temp file in project tmp directory
+	tmpFile, err := config.CreateTempFile("gh-pmu-history-*.html")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -91,6 +91,22 @@ type CreateIssueInput struct {
 	MilestoneID  *graphql.ID    `json:"milestoneId,omitempty"`
 }
 
+// CloseIssueInput represents the input for closing an issue
+type CloseIssueInput struct {
+	IssueID graphql.ID `json:"issueId"`
+}
+
+// ReopenIssueInput represents the input for reopening an issue
+type ReopenIssueInput struct {
+	IssueID graphql.ID `json:"issueId"`
+}
+
+// UpdateIssueInput represents the input for updating an issue
+type UpdateIssueInput struct {
+	ID   graphql.ID     `json:"id"`
+	Body graphql.String `json:"body,omitempty"`
+}
+
 // AddIssueToProject adds an issue to a GitHub Project V2
 func (c *Client) AddIssueToProject(projectID, issueID string) (string, error) {
 	if c.gql == nil {
@@ -688,9 +704,7 @@ func (c *Client) CloseIssue(issueID string) error {
 		} `graphql:"closeIssue(input: $input)"`
 	}
 
-	input := struct {
-		IssueID graphql.ID `json:"issueId"`
-	}{
+	input := CloseIssueInput{
 		IssueID: graphql.ID(issueID),
 	}
 
@@ -720,9 +734,7 @@ func (c *Client) ReopenIssue(issueID string) error {
 		} `graphql:"reopenIssue(input: $input)"`
 	}
 
-	input := struct {
-		IssueID graphql.ID `json:"issueId"`
-	}{
+	input := ReopenIssueInput{
 		IssueID: graphql.ID(issueID),
 	}
 
@@ -752,10 +764,7 @@ func (c *Client) UpdateIssueBody(issueID, body string) error {
 		} `graphql:"updateIssue(input: $input)"`
 	}
 
-	input := struct {
-		ID   graphql.ID     `json:"id"`
-		Body graphql.String `json:"body"`
-	}{
+	input := UpdateIssueInput{
 		ID:   graphql.ID(issueID),
 		Body: graphql.String(body),
 	}

--- a/internal/api/mutations_test.go
+++ b/internal/api/mutations_test.go
@@ -974,3 +974,219 @@ func TestGitCommit_ErrorMessageIncludesGitOutput(t *testing.T) {
 		}
 	}
 }
+
+// ============================================================================
+// CloseIssue, ReopenIssue, UpdateIssueBody Tests
+// ============================================================================
+
+func TestCloseIssue_NilClient(t *testing.T) {
+	client := &Client{gql: nil}
+
+	err := client.CloseIssue("issue-id")
+	if err == nil {
+		t.Fatal("Expected error when gql is nil")
+	}
+	if !strings.Contains(err.Error(), "GraphQL client not initialized") {
+		t.Errorf("Expected 'GraphQL client not initialized' error, got: %v", err)
+	}
+}
+
+func TestCloseIssue_Success(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			if name != "CloseIssue" {
+				t.Errorf("Expected mutation name 'CloseIssue', got '%s'", name)
+			}
+
+			// Verify input type is CloseIssueInput (not anonymous struct)
+			input, ok := variables["input"].(CloseIssueInput)
+			if !ok {
+				t.Fatal("Expected CloseIssueInput type in variables, got anonymous struct")
+			}
+			if input.IssueID.(string) != "issue-123" {
+				t.Errorf("Expected IssueID 'issue-123', got '%v'", input.IssueID)
+			}
+			return nil
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.CloseIssue("issue-123")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestCloseIssue_MutationError(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			return errors.New("mutation failed")
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.CloseIssue("issue-id")
+
+	if err == nil {
+		t.Fatal("Expected error when mutation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to close issue") {
+		t.Errorf("Expected 'failed to close issue' error, got: %v", err)
+	}
+}
+
+func TestReopenIssue_NilClient(t *testing.T) {
+	client := &Client{gql: nil}
+
+	err := client.ReopenIssue("issue-id")
+	if err == nil {
+		t.Fatal("Expected error when gql is nil")
+	}
+	if !strings.Contains(err.Error(), "GraphQL client not initialized") {
+		t.Errorf("Expected 'GraphQL client not initialized' error, got: %v", err)
+	}
+}
+
+func TestReopenIssue_Success(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			if name != "ReopenIssue" {
+				t.Errorf("Expected mutation name 'ReopenIssue', got '%s'", name)
+			}
+
+			// Verify input type is ReopenIssueInput (not anonymous struct)
+			input, ok := variables["input"].(ReopenIssueInput)
+			if !ok {
+				t.Fatal("Expected ReopenIssueInput type in variables, got anonymous struct")
+			}
+			if input.IssueID.(string) != "issue-456" {
+				t.Errorf("Expected IssueID 'issue-456', got '%v'", input.IssueID)
+			}
+			return nil
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.ReopenIssue("issue-456")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestReopenIssue_MutationError(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			return errors.New("mutation failed")
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.ReopenIssue("issue-id")
+
+	if err == nil {
+		t.Fatal("Expected error when mutation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to reopen issue") {
+		t.Errorf("Expected 'failed to reopen issue' error, got: %v", err)
+	}
+}
+
+func TestUpdateIssueBody_NilClient(t *testing.T) {
+	client := &Client{gql: nil}
+
+	err := client.UpdateIssueBody("issue-id", "new body")
+	if err == nil {
+		t.Fatal("Expected error when gql is nil")
+	}
+	if !strings.Contains(err.Error(), "GraphQL client not initialized") {
+		t.Errorf("Expected 'GraphQL client not initialized' error, got: %v", err)
+	}
+}
+
+func TestUpdateIssueBody_Success(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			if name != "UpdateIssue" {
+				t.Errorf("Expected mutation name 'UpdateIssue', got '%s'", name)
+			}
+
+			// Verify input type is UpdateIssueInput (not anonymous struct)
+			input, ok := variables["input"].(UpdateIssueInput)
+			if !ok {
+				t.Fatal("Expected UpdateIssueInput type in variables, got anonymous struct")
+			}
+			if input.ID.(string) != "issue-789" {
+				t.Errorf("Expected ID 'issue-789', got '%v'", input.ID)
+			}
+			if string(input.Body) != "updated body content" {
+				t.Errorf("Expected Body 'updated body content', got '%s'", input.Body)
+			}
+			return nil
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.UpdateIssueBody("issue-789", "updated body content")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestUpdateIssueBody_MutationError(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			return errors.New("mutation failed")
+		},
+	}
+
+	client := NewClientWithGraphQL(mock)
+	err := client.UpdateIssueBody("issue-id", "body")
+
+	if err == nil {
+		t.Fatal("Expected error when mutation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to update issue body") {
+		t.Errorf("Expected 'failed to update issue body' error, got: %v", err)
+	}
+}
+
+// ============================================================================
+// Issue Mutation Input Type Tests
+// ============================================================================
+
+func TestCloseIssueInput_HasRequiredFields(t *testing.T) {
+	input := CloseIssueInput{
+		IssueID: "issue-id",
+	}
+
+	if input.IssueID != "issue-id" {
+		t.Errorf("Expected IssueID 'issue-id', got '%s'", input.IssueID)
+	}
+}
+
+func TestReopenIssueInput_HasRequiredFields(t *testing.T) {
+	input := ReopenIssueInput{
+		IssueID: "issue-id",
+	}
+
+	if input.IssueID != "issue-id" {
+		t.Errorf("Expected IssueID 'issue-id', got '%s'", input.IssueID)
+	}
+}
+
+func TestUpdateIssueInput_HasRequiredFields(t *testing.T) {
+	input := UpdateIssueInput{
+		ID:   "issue-id",
+		Body: "new body",
+	}
+
+	if input.ID != "issue-id" {
+		t.Errorf("Expected ID 'issue-id', got '%s'", input.ID)
+	}
+	if input.Body != "new body" {
+		t.Errorf("Expected Body 'new body', got '%s'", input.Body)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix GraphQL CloseIssue/ReopenIssue/UpdateIssue mutations by using named input types instead of anonymous structs (#425)
- Exclude Parking Lot issues when closing a release (#426)
- Use project tmp/ directory for temporary files with auto .gitignore (#427)

## Test plan

- [x] All existing tests pass
- [x] New tests added for GraphQL input types
- [x] New tests added for Parking Lot exclusion
- [x] New tests added for temp file handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)