### PR TITLE
chore: prepare release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2025-12-23
+
+### Fixed
+- `gh pmu init` now detects all status and priority field values from project metadata (#442)
+  - Previously hardcoded values missed custom options like "Parking Lot"
+  - Now dynamically generates field mappings from actual project fields
+  - Handles emoji prefixes (e.g., "🅿️ Parking Lot" → `parking_lot` alias)
+
 ## [0.9.0] - 2025-12-23
 
 ### Added


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.9.1 release

## Changes in v0.9.1

### Fixed
- `gh pmu init` now detects all status and priority field values from project metadata (#442)

## Test plan

- [x] CHANGELOG.md follows Keep a Changelog format
- [x] Version number follows semver (PATCH bump for bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)