### PR TITLE
chore: add v0.9.2 release artifacts

### DIFF
--- a/.gh-pmu.yml
+++ b/.gh-pmu.yml
@@ -28,7 +28,6 @@ fields:
 triage:
     estimate:
         query: is:issue is:open -has:estimate
-        apply: {}
         interactive:
             estimate: true
 metadata:
@@ -119,3 +118,8 @@ metadata:
         - name: Microsprint
           id: PVTF_lAHOAATLPs4BJeuXzg6bQ8Y
           data_type: TEXT
+cache:
+    releases:
+        - number: 450
+          title: 'Release: release/v0.9.2'
+          state: CLOSED

--- a/Releases/release/v0.9.2/changelog.md
+++ b/Releases/release/v0.9.2/changelog.md
@@ -1,19 +1,5 @@
-# Changelog for v0.9.2
+## release/v0.9.2 (2025-12-23)
 
-## [0.9.2] - 2025-12-23
-
-### Added
-- `/prepare-release` workflow now updates GitHub release notes from CHANGELOG (#439)
-  - Parses CHANGELOG.md and updates corresponding GitHub release body
-  - Cleans up old release assets, keeping only 3 most recent tagged releases
-  - New scripts: `update-release-notes.js`, `cleanup-release-assets.js`
-
-### Performance
-- `gh pmu move` now caches project fields before bulk updates (#451)
-  - Eliminates N+1 API calls when updating multiple fields per issue
-  - 68-80% reduction in API calls for typical multi-field updates
-
-### Fixed
-- `release current` now shows accurate issue count (#449)
-  - Uses project items with field filtering instead of label-based query
-  - Fixes discrepancy between `release current` and `list --release current`
+- #439 enhancement: /prepare-release should create appropriate releases page
+- #449 Bug: release current shows 28 issues but list --release current shows 5
+- #451 perf: Cache GetProjectFields to eliminate N+1 query pattern in move command

--- a/Releases/release/v0.9.2/release-notes.md
+++ b/Releases/release/v0.9.2/release-notes.md
@@ -1,22 +1,15 @@
-# Release v0.9.2
+# Release release/v0.9.2
 
-## Highlights
+**Date:** 2025-12-23
 
-- **Performance**: `gh pmu move` now caches project fields, reducing API calls by 68-80%
-- **Accuracy**: `release current` issue count now matches `list --release current`
-- **Automation**: `/prepare-release` workflow updates GitHub release notes and cleans up old assets
+**Tracker:** #450
 
-## What's Changed
+## Features
 
-### Added
-- `/prepare-release` workflow now updates GitHub release notes from CHANGELOG (#439)
-  - Parses CHANGELOG.md and updates corresponding GitHub release body
-  - Cleans up old release assets, keeping only 3 most recent tagged releases
+- #439 enhancement: /prepare-release should create appropriate releases page
+- #451 perf: Cache GetProjectFields to eliminate N+1 query pattern in move command
 
-### Performance
-- `gh pmu move` now caches project fields before bulk updates (#451)
-  - Eliminates N+1 API calls when updating multiple fields per issue
+## Bug Fixes
 
-### Fixed
-- `release current` now shows accurate issue count (#449)
-  - Uses project items with field filtering instead of label-based query
+- #449 Bug: release current shows 28 issues but list --release current shows 5
+


### PR DESCRIPTION
## Summary
- Update release artifacts after `gh pmu release close`
- Update cache in .gh-pmu.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)