### PR TITLE
docs: add standalone usage section and move codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # gh-pmu
 
 [![CI](https://github.com/rubrical-studios/gh-pmu/actions/workflows/ci.yml/badge.svg)](https://github.com/rubrical-studios/gh-pmu/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/rubrical-studios/gh-pmu/graph/badge.svg)](https://codecov.io/gh/rubrical-studios/gh-pmu)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rubrical-studios/gh-pmu)](https://goreportcard.com/report/github.com/rubrical-studios/gh-pmu)
 [![Release](https://img.shields.io/github/v/release/rubrical-studios/gh-pmu)](https://github.com/rubrical-studios/gh-pmu/releases/latest)
 [![License](https://img.shields.io/github/license/rubrical-studios/gh-pmu)](LICENSE)
@@ -61,6 +60,35 @@ gh pmu microsprint close --commit
 gh pmu release start --branch release/v1.2.0
 gh pmu release add 42
 gh pmu release close
+```
+
+## Standalone Usage
+
+`gh pmu` works as a standalone tool without any framework integration. The optional `framework` field in `.gh-pmu.yml` enables workflow restrictions when used with process frameworks like [IDPF](https://github.com/rubrical-studios/virtual-ai-studio).
+
+**Standalone (default):**
+- All commands work normally
+- No workflow routing or approval gates
+- Simple project management
+
+**With framework integration:**
+- Adds workflow restrictions and checkpoint discipline
+- Structured patterns (epic→story hierarchies)
+- Domain specialist role system
+
+To use standalone, simply omit the `framework` field from your config:
+
+```yaml
+project:
+  owner: your-org
+  number: 1
+repositories:
+  - your-org/your-repo
+fields:
+  status:
+    values: {backlog, in_progress, in_review, done}
+  priority:
+    values: {p0, p1, p2}
 ```
 
 ## Documentation

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,9 +108,21 @@ gh workflow run integration-tests.yml -f test_type=all
 
 ## Test Coverage
 
+[![codecov](https://codecov.io/gh/rubrical-studios/gh-pmu/graph/badge.svg)](https://codecov.io/gh/rubrical-studios/gh-pmu)
+
 Coverage reports are available on [Codecov](https://codecov.io/gh/rubrical-studios/gh-pmu).
 
-Coverage is uploaded automatically on every CI run. Click the Codecov badge in the README for detailed per-file breakdown.
+Coverage is uploaded automatically on every CI run. Click the badge above for detailed per-file breakdown.
+
+### Why Coverage is ~68%
+
+The practical coverage ceiling is 68-70% due to functions that are difficult to unit test:
+
+- **Interactive CLI** - Functions using `os.Stdin` for prompts (`runInit`, `runFilter`)
+- **External processes** - Functions calling `exec.Command` for git operations
+- **Terminal UI** - Kanban board and history rendering requiring visual verification
+
+These are tested manually. Refactoring for testability is tracked in issues #415 and #416.
 
 For comprehensive testing strategy, coverage targets, and functions excluded from unit testing, see [TESTING.md](../TESTING.md).
 


### PR DESCRIPTION
## Summary
- Add "Standalone Usage" section to README explaining gh-pmu works independently without IDPF framework integration
- Move codecov badge from README to docs/development.md (more relevant location)
- Add "Why Coverage is ~68%" section explaining practical ceiling due to interactive CLI, external processes, and terminal UI

## Test plan
- [ ] Verify README renders correctly with new section
- [ ] Verify codecov badge displays in docs/development.md
- [ ] Verify links to IDPF and tracking issues work

🤖 Generated with [Claude Code](https://claude.com/claude-code)