### PR TITLE
fix: format edit_test.go struct alignment

### DIFF
--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -12,14 +12,14 @@ import (
 
 // mockEditClient implements editClient for testing
 type mockEditClient struct {
-	issue             *api.Issue
-	getIssueErr       error
-	updateBodyErr     error
-	updateTitleErr    error
-	addLabelErr       error
-	updateBodyCalls   []string
-	updateTitleCalls  []string
-	addLabelCalls     []string
+	issue            *api.Issue
+	getIssueErr      error
+	updateBodyErr    error
+	updateTitleErr   error
+	addLabelErr      error
+	updateBodyCalls  []string
+	updateTitleCalls []string
+	addLabelCalls    []string
 }
 
 func (m *mockEditClient) GetIssueByNumber(owner, repo string, number int) (*api.Issue, error) {


### PR DESCRIPTION
## Summary
- Fix struct field alignment in edit_test.go to pass gofmt check
- This was caught by CI after the v0.9.7 tag was created

🤖 Generated with [Claude Code](https://claude.com/claude-code)