### PR TITLE
fix: correct gofmt formatting in comment_test.go

### DIFF
--- a/cmd/comment_test.go
+++ b/cmd/comment_test.go
@@ -15,8 +15,8 @@ type mockCommentClient struct {
 	comment *api.Comment
 
 	// Error injection
-	getIssueErr      error
-	addCommentErr    error
+	getIssueErr   error
+	addCommentErr error
 }
 
 func newMockCommentClient() *mockCommentClient {


### PR DESCRIPTION
Fix whitespace alignment flagged by CI gofmt check.