### PR TITLE
fix: format embed.go struct tags

### DIFF
--- a/internal/defaults/embed.go
+++ b/internal/defaults/embed.go
@@ -12,8 +12,8 @@ var defaultsYAML []byte
 
 // Defaults holds the parsed default configuration.
 type Defaults struct {
-	Labels []LabelDef   `yaml:"labels"`
-	Fields FieldsDef    `yaml:"fields"`
+	Labels []LabelDef `yaml:"labels"`
+	Fields FieldsDef  `yaml:"fields"`
 }
 
 // LabelDef represents a label definition.


### PR DESCRIPTION
## Summary
Fix gofmt formatting issue in `internal/defaults/embed.go` - struct tag alignment.

## Test plan
- [x] `gofmt -s -l .` returns no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)