### PR TITLE
docs: update documentation for branch command and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/rubrical-studios/gh-pmu)](https://github.com/rubrical-studios/gh-pmu/releases/latest)
 [![License](https://img.shields.io/github/license/rubrical-studios/gh-pmu)](LICENSE)
 
-A GitHub CLI extension for project management and sub-issue hierarchy.
+**P**roject **M**anagement **U**nified — a GitHub CLI extension for project management and sub-issue hierarchy.
 
 ## Features
 
@@ -17,7 +17,7 @@ A GitHub CLI extension for project management and sub-issue hierarchy.
 
 📊 **Board View** - Terminal Kanban board visualization
 
-🚀 **Workflow Commands** - Release, patch, and microsprint management with artifact generation
+🚀 **Workflow Commands** - Branch and microsprint management with artifact generation
 
 🔄 **Cross-Repository** - Work with sub-issues across multiple repositories
 
@@ -56,10 +56,10 @@ gh pmu microsprint start
 gh pmu microsprint add 42
 gh pmu microsprint close --commit
 
-# Start a release (branch-based deployment)
-gh pmu release start --branch release/v1.2.0
-gh pmu release add 42
-gh pmu release close
+# Start a branch (release, patch, or feature workflow)
+gh pmu branch start --branch release/v1.2.0
+gh pmu branch add 42
+gh pmu branch close
 ```
 
 ## Standalone Usage
@@ -99,17 +99,17 @@ fields:
 | [Commands](docs/commands.md) | Complete command reference with examples |
 | [Sub-Issues](docs/sub-issues.md) | Parent-child hierarchies, epics, progress tracking |
 | [Batch Operations](docs/batch-operations.md) | Intake, triage, and split workflows |
-| [Workflows](docs/workflows.md) | Microsprint and release management |
+| [Workflows](docs/workflows.md) | Microsprint and branch management |
 | [gh vs gh pmu](docs/gh-comparison.md) | When to use each CLI |
 | [Development](docs/development.md) | Building, testing, contributing |
 
 ## Commands
 
 ```
-Project:    init, list, view, create, move, close, board, field
+Project:    init, list, view, create, edit, comment, move, close, board, field
 Sub-Issues: sub add, sub create, sub list, sub remove
 Batch:      intake, triage, split
-Workflows:  release, microsprint
+Workflows:  branch, microsprint
 Utilities:  filter, history
 ```
 
@@ -122,13 +122,15 @@ Flags and features not available in base `gh` CLI:
 | Command | Unique Flags | Purpose |
 |---------|--------------|---------|
 | `list` | `--status`, `--priority`, `--has-sub-issues` | Filter by project fields |
+| `view` | `--body-file`, `--body-stdout`, `--comments` | Export body, show comments |
 | `create` | `--status`, `--priority`, `--microsprint`, `--from-file` | Set project fields on create |
+| `edit` | `--body-file`, `--body-stdin`, `--remove-label` | Round-trip body editing |
 | `close` | `--update-status` | Move to 'done' before closing |
 | `move` | `--recursive`, `--dry-run`, `--depth`, `--microsprint` | Cascade updates to sub-issues |
 | `sub create` | `--inherit-labels`, `--inherit-milestone` | Inherit from parent issue |
 | `split` | `--from`, `--dry-run` | Create sub-issues from checklist |
 | `microsprint` | `start`, `add`, `close`, `--skip-retro`, `--commit` | AI-assisted development batches |
-| `release` | `start --branch`, `add`, `close` | Branch-based deployment workflow |
+| `branch` | `start`, `add`, `close`, `reopen`, `--tag` | Branch-based deployment workflow |
 
 See [gh vs gh pmu](docs/gh-comparison.md) for detailed comparison.
 

--- a/docs/gh-comparison.md
+++ b/docs/gh-comparison.md
@@ -23,6 +23,8 @@ These commands have no equivalent in the base `gh` CLI:
 | Command | Purpose |
 |---------|---------|
 | `gh pmu board` | Terminal Kanban board view |
+| `gh pmu comment` | Add comments to issues with stdin/file support |
+| `gh pmu edit` | Edit issue body with round-trip file workflow |
 | `gh pmu history` | Git commit history with issue reference parsing |
 | `gh pmu init` | Configure project connection per-repo |
 | `gh pmu intake` | Find issues not yet added to the project |
@@ -32,8 +34,7 @@ These commands have no equivalent in the base `gh` CLI:
 | `gh pmu triage` | Bulk rule-based issue processing |
 | `gh pmu field` | Create and list project fields |
 | `gh pmu microsprint` | AI-assisted development workflow (hour-scale batches) |
-| `gh pmu release` | Version-based deployment workflow |
-| `gh pmu patch` | Hotfix deployment workflow with validation |
+| `gh pmu branch` | Branch-based deployment workflow (releases, patches, hotfixes) |
 
 ### Unique Flags
 
@@ -54,7 +55,15 @@ Flags available in `gh pmu` that don't exist in base `gh`:
 | `move` | `--dry-run` | Preview changes without applying |
 | `move` | `--depth` | Limit recursion depth |
 | `move` | `--microsprint` | Assign to microsprint |
+| `move` | `--branch` | Assign to branch (use 'current' for active) |
+| `move` | `--backlog` | Clear branch and microsprint fields |
 | `move` | `--yes` | Skip confirmation prompt |
+| `view` | `--body-file` | Export body to tmp/issue-{n}.md |
+| `view` | `--body-stdout` | Output body to stdout |
+| `view` | `--comments` | Show issue comments |
+| `edit` | `--body-file` | Read body from file |
+| `edit` | `--body-stdin` | Read body from stdin |
+| `edit` | `--remove-label` | Remove labels from issue |
 | `sub create` | `--inherit-labels` | Copy labels from parent |
 | `sub create` | `--inherit-milestone` | Copy milestone from parent |
 | `sub create` | `--inherit-assignees` | Copy assignees from parent |
@@ -67,8 +76,6 @@ These base `gh` commands complement `gh pmu`:
 
 | Command | Purpose |
 |---------|---------|
-| `gh issue comment` | Add comments to issues |
-| `gh issue edit` | Edit title, body, labels, assignees |
 | `gh issue develop` | Create linked branches |
 | `gh issue pin/unpin` | Pin issues to repository |
 | `gh issue transfer` | Move issue to another repository |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -5,7 +5,7 @@ gh-pmu provides workflow command groups for managing development at different ca
 | Workflow | Cadence | Use Case |
 |----------|---------|----------|
 | `microsprint` | Hours | AI-assisted development batches, rapid iteration |
-| `release` | Days/Weeks | Branch-based deployment, feature releases, patches, hotfixes |
+| `branch` | Days/Weeks | Branch-based deployment, feature releases, patches, hotfixes |
 
 ## Microsprint
 
@@ -87,54 +87,59 @@ gh pmu microsprint resolve
 
 ---
 
-## Release
+## Branch
 
-Releases are branch-based deployment workflows for feature releases, patches, and hotfixes. The branch name is used literally for all release artifacts.
+Branch workflows are used for feature releases, patches, and hotfixes. The branch name is used literally for all artifacts.
 
-### Starting a Release
+### Starting a Branch
 
 ```bash
 # Start a feature release
-gh pmu release start --branch release/v2.0.0
+gh pmu branch start --branch release/v2.0.0
 
 # Start a patch release
-gh pmu release start --branch patch/v1.9.1
+gh pmu branch start --branch patch/v1.9.1
 
 # Start a hotfix
-gh pmu release start --branch hotfix-auth-bypass
+gh pmu branch start --branch hotfix-auth-bypass
 ```
 
-The command creates the git branch and a tracker issue with the `release` label.
+The command creates the git branch and a tracker issue with the `branch` label.
 
 ### Managing Issues
 
 ```bash
-# Add issue to current release
-gh pmu release add 42
+# Add issue to current branch
+gh pmu branch add 42
 
-# Remove issue from release
-gh pmu release remove 42
+# Remove issue from branch
+gh pmu branch remove 42
 
-# Create new issue directly in release
-gh pmu create --title "Add dark mode" --status in_progress
-gh pmu release add <new-issue-number>
+# Create new issue directly in branch
+gh pmu create --title "Add dark mode" --status in_progress --branch current
 ```
 
 ### Viewing Status
 
 ```bash
-# Show current release details
-gh pmu release current
+# Show current branch details
+gh pmu branch current
 
-# List all releases
-gh pmu release list
+# List all branches
+gh pmu branch list
+
+# Reopen a closed branch
+gh pmu branch reopen release/v1.9.0
 ```
 
-### Closing a Release
+### Closing a Branch
 
 ```bash
-# Close release and generate artifacts
-gh pmu release close
+# Close branch and generate artifacts
+gh pmu branch close
+
+# Close with git tag
+gh pmu branch close --tag
 ```
 
 **Generated artifacts** (configurable):
@@ -169,30 +174,20 @@ Workflows use labels for tracker issues:
 | Label | Used By |
 |-------|---------|
 | `microsprint` | Microsprint tracker issues |
-| `release` | Release tracker issues |
+| `branch` | Branch tracker issues |
 
 Run `gh pmu init` to auto-create these labels.
 
-### Release Artifacts
+### Branch Artifacts
 
 Configure artifact generation in `.gh-pmu.yml`:
 
 ```yaml
-release:
+branch:
   artifacts:
     directory: "Releases"      # Base directory (default)
     release_notes: true        # Generate release-notes.md
     changelog: true            # Generate changelog.md
-
-  tracks:
-    - name: main
-      prefix: ""               # No prefix: Releases/v1.2.0/
-    - name: lts
-      prefix: "lts-"           # Prefixed: Releases/lts-v1.2.0/
-
-  # Active releases (auto-synced by init)
-  active:
-    - "1.2.0"
 ```
 
 ---
@@ -218,7 +213,7 @@ gh pmu create --title "New feature" --microsprint current
 ```bash
 # See what workflows are active
 gh pmu microsprint current
-gh pmu release current
+gh pmu branch current
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add PMU acronym explanation (Project Management Unified) to README
- Replace deprecated `release` command with `branch` throughout documentation
- Add `edit` and `comment` commands to README and comparison docs
- Document new flags for `view`, `edit`, and `move` commands

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Check all internal doc links work
- [ ] Confirm command examples match actual CLI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)