### PR TITLE
Release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-01-20
+
+### Changed
+- Renamed project text field from "Release" to "Branch" in defaults (#603)
+- Updated all command help text to reference "Branch" field instead of "Release"
+- Added backward compatibility for existing projects with "Release" field
+  - Commands check for "Branch" field first, fall back to "Release"
+  - No migration required for existing projects
+
 ## [0.13.1] - 2026-01-19
 
 ### Added

--- a/Releases/release/v0.13.2/changelog.md
+++ b/Releases/release/v0.13.2/changelog.md
@@ -1,0 +1,24 @@
+# Changelog for v0.13.2
+
+## Changed
+
+- Renamed project text field from "Release" to "Branch" in defaults (#603)
+- Updated all command help text to reference "Branch" field
+- Added backward compatibility for existing projects with "Release" field
+
+## Technical Details
+
+### Files Modified
+- `internal/defaults/defaults.yml` - Field name change
+- `cmd/fieldnames.go` - New file with field name constants and resolution
+- `cmd/branch.go` - Updated field references and help text
+- `cmd/move.go` - Updated field references
+- `cmd/create.go` - Updated field references and interface
+- `cmd/list.go` - Added dual-field filtering
+- `cmd/validation.go` - Updated context builder
+
+### Migration Notes
+No migration required. The change is backward compatible:
+1. Commands check for "Branch" field first
+2. Fall back to "Release" field for existing projects
+3. New projects get "Branch" field from init

--- a/Releases/release/v0.13.2/release-notes.md
+++ b/Releases/release/v0.13.2/release-notes.md
@@ -1,0 +1,32 @@
+# Release v0.13.2
+
+## Summary
+
+This patch release renames the project text field from "Release" to "Branch" to align with the updated branch semantics where any branch (not just release branches) can be used for tracking work. Full backward compatibility is maintained for existing projects.
+
+## What's New
+
+### Field Renamed: Release to Branch (#603)
+
+The project field used for tracking branch assignments has been renamed from "Release" to "Branch". This aligns with the previously deprecated `--release` flag being replaced by `--branch`.
+
+**Backward Compatibility:**
+- Existing projects with a "Release" field continue to work
+- New projects created with `gh pmu init` get a "Branch" field
+- Commands automatically detect which field exists and use it
+
+**No action required** for existing users - the change is transparent.
+
+### Updated Help Text
+
+All command help text and documentation now references "Branch" instead of "Release" for consistency.
+
+## Installation
+
+```bash
+gh extension upgrade rubrical-studios/gh-pmu
+```
+
+## Full Changelog
+
+https://github.com/rubrical-studios/gh-pmu/compare/v0.13.1...v0.13.2

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -1761,8 +1761,8 @@ func TestGenerateBranchTrackerTemplate_ContainsIssuesSection(t *testing.T) {
 	if !strings.Contains(result, "## Issues in this branch") {
 		t.Error("Template should contain 'Issues in this branch' section")
 	}
-	if !strings.Contains(result, "Release field in the project") {
-		t.Error("Template should explain issues are tracked via the Release field")
+	if !strings.Contains(result, "Branch field in the project") {
+		t.Error("Template should explain issues are tracked via the Branch field")
 	}
 }
 

--- a/cmd/fieldnames.go
+++ b/cmd/fieldnames.go
@@ -1,0 +1,60 @@
+package cmd
+
+import "github.com/rubrical-studios/gh-pmu/internal/api"
+
+// Field name constants for project fields.
+// The Branch field was previously named Release. For backward compatibility,
+// we check for Branch first and fall back to Release for existing projects.
+const (
+	// BranchFieldName is the current name for the branch tracking field.
+	BranchFieldName = "Branch"
+
+	// LegacyReleaseFieldName is the legacy name for the branch tracking field.
+	// Used for backward compatibility with existing projects.
+	LegacyReleaseFieldName = "Release"
+
+	// MicrosprintFieldName is the name of the microsprint tracking field.
+	MicrosprintFieldName = "Microsprint"
+)
+
+// ResolveBranchFieldName returns the appropriate field name for branch tracking
+// based on available project fields. It checks for "Branch" first and falls back
+// to "Release" for backward compatibility with existing projects.
+func ResolveBranchFieldName(fields []api.ProjectField) string {
+	hasBranch := false
+	hasRelease := false
+
+	for _, f := range fields {
+		switch f.Name {
+		case BranchFieldName:
+			hasBranch = true
+		case LegacyReleaseFieldName:
+			hasRelease = true
+		}
+	}
+
+	// Prefer Branch field if it exists
+	if hasBranch {
+		return BranchFieldName
+	}
+
+	// Fall back to Release for existing projects
+	if hasRelease {
+		return LegacyReleaseFieldName
+	}
+
+	// Default to Branch for new projects (field may not exist yet)
+	return BranchFieldName
+}
+
+// ResolveBranchFieldNameFromFieldValues returns the appropriate field name for branch tracking
+// based on field values. This is useful when you have FieldValue slices instead of ProjectField slices.
+func ResolveBranchFieldNameFromFieldValues(fieldValues []api.FieldValue) string {
+	for _, fv := range fieldValues {
+		if fv.Field == BranchFieldName {
+			return BranchFieldName
+		}
+	}
+	// Default to legacy name if Branch not found in values
+	return LegacyReleaseFieldName
+}

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -297,10 +297,15 @@ func getFieldValueFromSlice(fieldValues []api.FieldValue, fieldName string) stri
 
 // buildValidationContext creates a validation context from project item data
 func buildValidationContext(number int, body string, fieldValues []api.FieldValue, activeReleases []string) *issueValidationContext {
+	// Check both "Branch" (new) and "Release" (legacy) field names for backward compatibility
+	currentBranch := getFieldValueFromSlice(fieldValues, BranchFieldName)
+	if currentBranch == "" {
+		currentBranch = getFieldValueFromSlice(fieldValues, LegacyReleaseFieldName)
+	}
 	return &issueValidationContext{
 		Number:         number,
 		CurrentStatus:  getFieldValueFromSlice(fieldValues, "Status"),
-		CurrentRelease: getFieldValueFromSlice(fieldValues, "Release"),
+		CurrentRelease: currentBranch,
 		Body:           body,
 		ActiveReleases: activeReleases,
 	}

--- a/internal/defaults/defaults.yml
+++ b/internal/defaults/defaults.yml
@@ -48,7 +48,7 @@ fields:
         - P0
         - P1
         - P2
-    - name: Release
+    - name: Branch
       type: TEXT
     - name: Microsprint
       type: TEXT

--- a/internal/defaults/embed_test.go
+++ b/internal/defaults/embed_test.go
@@ -99,7 +99,7 @@ func TestLoad_HasCreateIfMissingFields(t *testing.T) {
 
 	expectedFields := map[string]string{
 		"Priority":    "SINGLE_SELECT",
-		"Release":     "TEXT",
+		"Branch":      "TEXT",
 		"Microsprint": "TEXT",
 	}
 


### PR DESCRIPTION
## Summary

- Rename project text field from "Release" to "Branch" (#603)
- Add backward compatibility for existing projects

## Changes

- `internal/defaults/defaults.yml` - Field name change
- `cmd/fieldnames.go` - New file with field constants and resolution
- `cmd/branch.go`, `cmd/move.go`, `cmd/create.go`, `cmd/list.go`, `cmd/validation.go` - Updated field references
- Test files updated

## Test plan

- [x] Unit tests pass
- [x] E2E tests pass (12/12)
- [x] Coverage meets threshold (70.8%)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)