### PR TITLE
Release v0.13.8

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -56,7 +56,6 @@ gh pmu branch current --json issues | jq '.[] | select(.status != "done")'
 git log $(git describe --tags --abbrev=0)..HEAD --oneline
 ```
 
-<!-- USER-EXTENSION-START: post-analysis -->
 ### Analyze Commits
 
 ```bash
@@ -75,6 +74,8 @@ node .claude/scripts/framework/recommend-version.js
 ```
 
 Uses the commit analysis to recommend a version bump.
+
+<!-- USER-EXTENSION-START: post-analysis -->
 
 ### Documentation Review
 
@@ -98,9 +99,11 @@ The script analyzes which E2E tests may be impacted by changes:
 - `recommendation`: Suggested test review actions
 
 **If `newCommandsWithoutTests` is non-empty, warn user about missing coverage.**
+
 <!-- USER-EXTENSION-END: post-analysis -->
 
 **ASK USER:** Confirm version.
+
 ## Phase 2: Validation
 
 <!-- USER-EXTENSION-START: pre-validation -->
@@ -122,14 +125,17 @@ The script outputs JSON: `{"success": true/false, "message": "..."}`
 **If `success` is false, STOP and report the error.**
 
 Runs `golangci-lint run --timeout=5m` to catch lint errors before tagging.
+
 <!-- USER-EXTENSION-END: pre-validation -->
 
+<!-- USER-EXTENSION-START: post-validation -->
+
 ### Step 2.1: Run Tests
+
 ```bash
 go test ./...
 ```
 
-<!-- USER-EXTENSION-START: post-validation -->
 ### Coverage Gate
 
 **If `--skip-coverage` was passed, skip this section.**
@@ -209,7 +215,7 @@ gh pr create --base main --head $(git branch --show-current) --title "Release $V
 
 ### Wait for CI
 ```bash
-node .claude/scripts/framework/wait-for-ci.js
+node .claude/scripts/shared/wait-for-ci.js
 ```
 **If CI fails, STOP and report.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.8] - 2026-01-24
+
+### Changed
+- Error message for unchecked checkboxes now includes Claude workflow reminder (#635)
+
 ## [0.13.7] - 2026-01-23
 
 ### Added

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -102,7 +102,7 @@ func validateStatusTransition(cfg *config.Config, ctx *issueValidationContext, t
 			return &ValidationError{
 				IssueNumber: ctx.Number,
 				Message:     fmt.Sprintf("Has %d unchecked checkbox(es):%s", unchecked, itemList),
-				Suggestion:  fmt.Sprintf("Complete these items before moving to %s, or use --force to bypass.", targetStatus),
+				Suggestion:  fmt.Sprintf("Complete these items before moving to %s, or use --force to bypass.\nClaude: Review GitHub-Workflow rules before using --force.", targetStatus),
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Enhancement #635: Add Claude workflow reminder to `--force` bypass suggestion
- Framework: Adjust extension tag positions in prepare-release.md

## Changes
- `cmd/validation.go`: Error message now includes "Claude: Review GitHub-Workflow rules before using --force."
- `.claude/commands/prepare-release.md`: Moved extension tags to correct positions
- `CHANGELOG.md`: Added v0.13.8 entry

## Test plan
- [x] All unit tests pass
- [x] Coverage gate passed (70.8%)
- [x] E2E tests passed (22/22)
- [x] Lint passed

Refs #635
