### PR TITLE
Release v0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.9] - 2026-01-24
+
+### Added
+- Claude workflow reminder automatically prepended to issue bodies in IDPF projects (#638)
+
 ## [0.13.8] - 2026-01-24
 
 ### Changed

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -218,6 +218,11 @@ func runCreateWithDeps(cmd *cobra.Command, opts *createOptions, cfg *config.Conf
 	labels := append([]string{}, cfg.Defaults.Labels...)
 	labels = append(labels, opts.labels...)
 
+	// Add Claude workflow reminder for IDPF projects
+	if cfg.IsIDPF() && body != "" {
+		body = prependClaudeReminder(body)
+	}
+
 	// Create the issue with extended options
 	issue, err := client.CreateIssueWithOptions(owner, repo, title, body, labels, opts.assignees, opts.milestone)
 	if err != nil {
@@ -377,6 +382,11 @@ func runCreateFromFileWithDeps(cmd *cobra.Command, opts *createOptions, cfg *con
 	priority := issueData.Priority
 	if opts.priority != "" {
 		priority = opts.priority
+	}
+
+	// Add Claude workflow reminder for IDPF projects
+	if cfg.IsIDPF() && body != "" {
+		body = prependClaudeReminder(body)
 	}
 
 	// Create the issue
@@ -625,4 +635,16 @@ func decodeBase64Content(encoded string) (string, error) {
 		return "", err
 	}
 	return string(decoded), nil
+}
+
+// claudeReminder is the workflow reminder for Claude Code in IDPF projects
+const claudeReminder = "> **Claude:** Before acting, review `.claude/rules/02-github-workflow.md`. Wait for explicit \"work\" trigger.\n\n"
+
+// prependClaudeReminder adds the Claude workflow reminder to the top of the body
+// if it's not already present. Used for IDPF framework projects.
+func prependClaudeReminder(body string) string {
+	if strings.Contains(body, "Claude:") && strings.Contains(body, "github-workflow") {
+		return body
+	}
+	return claudeReminder + body
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -165,6 +165,10 @@ func runEditWithDeps(cmd *cobra.Command, opts *editOptions, cfg *config.Config, 
 		body = content
 	}
 	if body != "" {
+		// Add Claude workflow reminder for IDPF projects
+		if cfg.IsIDPF() {
+			body = prependClaudeReminder(body)
+		}
 		if err := client.UpdateIssueBody(issue.ID, body); err != nil {
 			return fmt.Errorf("failed to update body: %w", err)
 		}


### PR DESCRIPTION
## Summary
- Feature #638: Add Claude workflow reminder to IDPF issue bodies
- Automatically prepends reminder when creating/editing issues in IDPF projects
- Reminder text: `> **Claude:** Before acting, review .claude/rules/02-github-workflow.md. Wait for explicit "work" trigger.`

## Changes
- `cmd/create.go`: Added `prependClaudeReminder()` function, called for IDPF projects
- `cmd/edit.go`: Calls `prependClaudeReminder()` when updating body
- `cmd/create_test.go`: Added 3 unit tests for reminder logic
- `CHANGELOG.md`: Added v0.13.9 entry

## Test plan
- [x] All unit tests pass (including 3 new tests for reminder logic)
- [x] Coverage gate passed (70.8%)
- [x] E2E tests passed (22/22)
- [x] Lint passed

Refs #638
