### PR TITLE
style: fix gofmt formatting for v0.14.0

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,21 +30,21 @@ type createClient interface {
 }
 
 type createOptions struct {
-	title       string
-	body        string
-	bodyFile    string
-	bodyStdin   bool
-	editor      bool
-	template    string
-	web         bool
-	status      string
-	priority    string
-	release     string
-	labels      []string
-	assignees   []string
-	milestone   string
-	repo        string
-	fromFile    string
+	title     string
+	body      string
+	bodyFile  string
+	bodyStdin bool
+	editor    bool
+	template  string
+	web       bool
+	status    string
+	priority  string
+	release   string
+	labels    []string
+	assignees []string
+	milestone string
+	repo      string
+	fromFile  string
 }
 
 func newCreateCommand() *cobra.Command {

--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -659,14 +659,14 @@ func (c *Client) CopyProjectFromTemplate(ownerID, sourceProjectID, title string)
 	}
 
 	input := struct {
-		OwnerId         graphql.ID     `json:"ownerId"`
-		ProjectId       graphql.ID     `json:"projectId"`
-		Title           graphql.String `json:"title"`
+		OwnerId            graphql.ID      `json:"ownerId"`
+		ProjectId          graphql.ID      `json:"projectId"`
+		Title              graphql.String  `json:"title"`
 		IncludeDraftIssues graphql.Boolean `json:"includeDraftIssues"`
 	}{
-		OwnerId:         graphql.ID(ownerID),
-		ProjectId:       graphql.ID(sourceProjectID),
-		Title:           graphql.String(title),
+		OwnerId:            graphql.ID(ownerID),
+		ProjectId:          graphql.ID(sourceProjectID),
+		Title:              graphql.String(title),
 		IncludeDraftIssues: graphql.Boolean(false),
 	}
 


### PR DESCRIPTION
Fix gofmt alignment in cmd/create.go and internal/api/mutations.go