### PR TITLE
docs: update charter title to full project name

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,4 +1,4 @@
-# Project Charter: gh-pmu
+# Project Charter: GitHub Project Management Unified
 
 **Status:** Active
 **Last Updated:** 2026-01-21


### PR DESCRIPTION
Update CHARTER.md title from "gh-pmu" to "GitHub Project Management Unified".