### PR TITLE
chore: apply lint fixes for v1.1.0

### DIFF
--- a/cmd/view.go
+++ b/cmd/view.go
@@ -46,7 +46,6 @@ type viewResult struct {
 	subIssues   []api.SubIssue
 	parentIssue *api.Issue
 	comments    []api.Comment
-	err         error
 }
 
 type viewOptions struct {

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -1771,7 +1771,7 @@ func TestRunViewMulti_JSONArray(t *testing.T) {
 	w.Close()
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1815,7 +1815,7 @@ func TestRunViewMulti_TableWithSeparator(t *testing.T) {
 	w.Close()
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1865,9 +1865,9 @@ func TestRunViewMulti_InvalidIssuePartialSuccess(t *testing.T) {
 	os.Stdout = old
 	os.Stderr = oldErr
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	var errBuf bytes.Buffer
-	io.Copy(&errBuf, rErr)
+	_, _ = io.Copy(&errBuf, rErr)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1965,7 +1965,7 @@ func TestRunViewMulti_JQWithArray(t *testing.T) {
 	w.Close()
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- Remove unused `err` field from `viewResult` struct in `cmd/view.go`
- Suppress unchecked `io.Copy` return values in `cmd/view_test.go`

These lint fixes were stashed during the v1.1.0 release process and need to land before tagging.

## Test plan
- [x] `go vet ./...` passes