### PR TITLE
fix: gofmt formatting in move_test.go

### DIFF
--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -2942,9 +2942,9 @@ func TestRunMoveWithDeps_RecursiveBatchFallback_NilMap(t *testing.T) {
 	// Sub-issues available for individual fetch (fallback)
 	mock.subIssues["testowner/testrepo#1"] = []api.SubIssue{
 		{
-			ID:     "issue-2",
-			Number: 2,
-			Title:  "Sub Issue",
+			ID:         "issue-2",
+			Number:     2,
+			Title:      "Sub Issue",
 			Repository: api.Repository{Owner: "testowner", Name: "testrepo"},
 		},
 	}


### PR DESCRIPTION
Fix gofmt formatting issue causing CI lint failure on v1.3.0 tag.