### PR TITLE
chore: drop Go 1.22, require Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23']
 
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23']
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rubrical-works/gh-pmu
 
-go 1.22
+go 1.23
 
 require (
 	github.com/cli/go-gh/v2 v2.11.1


### PR DESCRIPTION
Go 1.22 EOL. Removes 1.22 from CI matrix and bumps go.mod to 1.23. Fixes CI failures blocking release asset uploads.