### PR TITLE
Release v1.4.1

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,32 @@
+name: Gosec
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Sundays at 01:00 UTC
+    - cron: '0 1 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gosec:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Gosec
+        uses: securego/gosec@master
+        with:
+          args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gosec-results.sarif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/rubrical-works/gh-pmu/actions/workflows/ci.yml/badge.svg)](https://github.com/rubrical-works/gh-pmu/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rubrical-works/gh-pmu)](https://goreportcard.com/report/github.com/rubrical-works/gh-pmu)
 [![Release](https://img.shields.io/github/v/release/rubrical-works/gh-pmu)](https://github.com/rubrical-works/gh-pmu/releases/latest)
+[![Gosec](https://github.com/rubrical-works/gh-pmu/actions/workflows/gosec.yml/badge.svg)](https://github.com/rubrical-works/gh-pmu/actions/workflows/gosec.yml)
 [![License](https://img.shields.io/github/license/rubrical-works/gh-pmu)](LICENSE)
 
 **P**raxis **M**anagement **U**tility — a GitHub CLI extension for project workflows, sub-issue hierarchies, and batch operations.


### PR DESCRIPTION
## Summary
- Add gosec security scanning workflow with SARIF upload
- Resolve all gosec findings (G306/G301/G302/G104 permissions and error handling)
- Remove `.gh-pmu.yml` dependencies — JSON-only config throughout
- Add critical config field drift detection in `config verify`
- Fix E2E test JSON type assertion

## Changes
- **Security:** Gosec CI workflow, tightened file/dir permissions, handled unhandled errors
- **Config:** Init writes JSON only, DetectFramework/loadExistingFramework read JSON, YAML fallback removed
- **Config verify:** Boxed alert on stderr when project.owner/number/repositories[0] change
- **Tests:** All fixtures migrated from YAML to JSON, new behavior tests added

## Test plan
- [x] Unit tests: all pass (70.8% coverage)
- [x] E2E tests: 24/24 pass
- [x] Lint: clean
- [x] Gosec: clean (G304 excluded as expected for CLI)
- [x] CodeQL: pass
