### PR TITLE
Release v1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.9] - 2026-05-05
+
+### Fixed
+- `gh pmu init --source-project` now refuses by default when `.gh-pmu.json` already declares a project number — protects against silently replacing the project pointer when the user actually wanted to re-link via `--project <existing>`. New `--force` flag opts in to the explicit-replace path. (#847)
+- `init` is now atomic: any hard failure after destination-project creation (field validation, refetch, config write) deletes the just-created project so no orphan is left on the org, and `.gh-pmu.json` is only written as the very last step. Previously a transient 5xx mid-init left an empty project on the org and a `.gh-pmu.json` rewritten to point at it. (#847)
+- `init` hard failures emit a structured trailer on stderr (`destinationProjectNumber=N`, `failedStep=...`, `configRewritten=bool`) so callers like px-manager can branch on machine-readable fields instead of screen-scraping. (#847)
+- All gh-pmu commands now retry transparently on transient GitHub HTTP errors — `IsRetryable` classifier covers 502/503/504 in addition to 429/rate-limited 403, and the retry decorator is installed at API client construction so every command (`init`, `edit`, `view`, etc.) inherits it without per-call-site wrapping. Closes a long-standing latent gap where typed-GraphQL errors from go-gh's underlying `shurcoolGraphQL` weren't matched by the rate-limit classifier. (#849)
+
+### Added
+- `internal/api.IsTransient5xx` and `internal/api.IsRetryable` classifiers; `internal/api.DeleteProject` mutation for init rollback. (#847, #849)
+- `--force` flag on `gh pmu init` (overrides the `--source-project` guard described above). (#847)
+
+### Changed
+- `WithRetry` now uses `IsRetryable` (rate-limit ∪ transient 5xx) and applies positive-bias jitter to default retry delays to spread coordinated-client retries. `Retry-After` header still overrides default delay exactly. (#849)
+
 ## [1.4.8] - 2026-04-29
 
 ### Fixed

--- a/Construction/Design-Decisions/2026-05-05-init-atomicity-defer-with-rollback.md
+++ b/Construction/Design-Decisions/2026-05-05-init-atomicity-defer-with-rollback.md
@@ -1,0 +1,60 @@
+# Design Decision: init Atomicity — Defer with Rollback
+
+**Date:** 2026-05-05
+**Status:** Accepted
+**Context:** Issue #847 — init is non-atomic; destination project created up front leaves orphan on post-create failures
+
+## Decision
+
+`gh pmu init --source-project N` adopts the **defer** atomicity model:
+
+1. Pre-flight checks and project creation run as before. If `CopyProjectFromTemplate` fails, no on-disk state has been written; nothing to roll back.
+2. After project creation, all remaining setup (field validation, optional-field creation, label loop, refetch, config write) runs inside an atomicity boundary in `runInitPostCreate` (`cmd/init_atomic.go`).
+3. **`writeConfigWithMetadata` is the last step.** If any prior step hard-fails, `.gh-pmu.json` is never touched.
+4. **On any hard failure inside the boundary:**
+   - Emit the structured failure trailer (`destinationProjectNumber=N`, `failedStep=...`, `configRewritten=bool`) on stderr.
+   - Call `client.DeleteProject(newProject.ID)` to roll back the orphan. Best-effort — a rollback failure is logged but does not mask the original error.
+5. **The label loop stays warn+continue** (per AC5). #849's retry layer transparently handles transient 5xx; persistent label failures are repo-config issues the user fixes externally. Treating them as hard errors would force users to clean up partial state before each retry — worse UX for non-essential setup.
+
+## Rationale
+
+The bug was: `init` creates a destination GitHub Project early, then performs several steps that can hard-fail. Any failure between project creation and the final config write left the user with an orphan project on the org and (in the worst case) a `.gh-pmu.json` rewritten to point at it.
+
+Two atomicity strategies were considered:
+
+- **Rollback variant:** snapshot `.gh-pmu.json` to `.gh-pmu.json.bak` before writing, restore on failure.
+- **Defer variant (chosen):** write `.gh-pmu.json` only as the very last step, after every fallible operation has succeeded. On failure, no on-disk state needs restoration.
+
+## Alternatives Considered
+
+- **Rollback (snapshot + restore):** rejected. Adds a backup-file lifecycle, races on concurrent writes, and Windows file-locking edge cases. The defer variant achieves the same atomicity guarantee without introducing a new on-disk artifact.
+- **Pre-flight validation only:** validate the source project's fields and target repo's labels *before* creating the destination project, so we never enter a state where rollback is needed. Rejected as scope creep — it adds GraphQL round-trips for every init even when the upstream is healthy, and doesn't fully eliminate post-create failure modes (e.g., the optional-field-creation path).
+- **Make the label loop fail-fast (#847 AC5 option B):** rejected. With #849's retry layer transparent to callers, surviving label-loop errors are persistent (permission, malformed labels, sustained outage) rather than transient. Fail-fast on those errors would block init entirely on a non-essential issue and force the user to clean up partial state. Warn+continue lets init finish; users fix labels externally and re-run if needed.
+
+## Consequences
+
+**Positive:**
+- Single source of truth for "did init succeed?" — the absence of `.gh-pmu.json` (or its unchanged pre-run state) is sufficient signal.
+- No `.gh-pmu.json.bak` artifact left around if the process is killed mid-write.
+- Callers (e.g., px-manager `#895`) get a structured failure trailer with `destinationProjectNumber`, `failedStep`, and `configRewritten` fields they can branch on without screen-scraping.
+- Future-proof: adding new fallible steps means adding a new `failedStep` enum value and slotting the call inside the boundary; no new rollback bookkeeping per step.
+
+**Negative / Trade-offs:**
+- `client.DeleteProject` is best-effort. If it fails (network blip during rollback), the user is left with the orphan AND the trailer pointing at it. Mitigated by emitting a clear `warning: rollback DeleteProject(...) failed` line so the user knows to clean up manually.
+- `writeConfigWithMetadata` itself can leave a partially-written file on Windows (POSIX rename atomicity isn't guaranteed cross-platform). The trailer flags `configRewritten=true` defensively in this case so callers know not to trust the file.
+- A failure between `CopyProjectFromTemplate` succeeding and `runInitPostCreate` returning means the project briefly existed and was deleted — the orphan window is small but non-zero. Acceptable.
+
+## Issues Encountered
+
+None during implementation. The biggest design clarification was deciding whether the label loop should participate in the atomicity boundary; AC5 of #847 explicitly raised this as a sub-decision and we documented the warn+continue rationale.
+
+## Files Touched
+
+- `cmd/init_atomic.go` (new) — `runInitPostCreate` + `initPostCreateClient` interface
+- `cmd/init.go` — wire `runInitPostCreate` into `runInitNonInteractive`; add `--source-project` guard + `--force` flag
+- `cmd/init_failure.go` (new) — structured failure trailer + `failedStep` enum
+- `internal/api/mutations.go` — `DeleteProject` mutation
+- `cmd/init_test.go` — atomicity tests, guard tests, trailer tests
+
+---
+*Documented during completion of #847.*

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -158,7 +158,7 @@ func runInitNonInteractive(cmd *cobra.Command, opts *initOptions) error {
 		return clientErr
 	}
 
-	// Get owner ID for the new project
+	// Get owner ID for the new project (no project created yet — no rollback needed on failure)
 	ownerID, err := client.GetOwnerID(owner)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: failed to get owner ID for %s: %v\n", owner, err)
@@ -168,21 +168,23 @@ func runInitNonInteractive(cmd *cobra.Command, opts *initOptions) error {
 	// Fetch source project to copy from
 	sourceProject, err := client.GetProject(owner, opts.sourceProject)
 	if err != nil {
+		printInitFailureTrailer(os.Stderr, 0, FailedStepSourceCopy, false)
 		fmt.Fprintf(os.Stderr, "error: failed to find source project %s/%d: %v\n", owner, opts.sourceProject, err)
 		return fmt.Errorf("failed to find source project: %w", err)
 	}
 
-	// Derive project title from repository name
 	projectTitle := deriveProjectTitle(repoName)
 
-	// Copy project from source
+	// Copy project from source — once this succeeds, every subsequent hard
+	// failure must roll back via client.DeleteProject (handled by runInitPostCreate).
 	newProject, err := client.CopyProjectFromTemplate(ownerID, sourceProject.ID, projectTitle)
 	if err != nil {
+		printInitFailureTrailer(os.Stderr, 0, FailedStepCreateProject, false)
 		fmt.Fprintf(os.Stderr, "error: failed to create project from source: %v\n", err)
 		return fmt.Errorf("failed to create project from source: %w", err)
 	}
 
-	// Link repository to the new project
+	// Link repository — warn-only (non-essential to atomicity).
 	repoID, err := client.GetRepositoryID(repoOwner, repoName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not get repository ID: %v\n", err)
@@ -192,98 +194,18 @@ func runInitNonInteractive(cmd *cobra.Command, opts *initOptions) error {
 		}
 	}
 
-	// Load embedded defaults
 	defs, err := defaults.Load()
 	if err != nil {
+		// Defaults are embedded; this is a build-time issue, not a runtime one.
+		// Roll back since we can't proceed.
+		printInitFailureTrailer(os.Stderr, newProject.Number, FailedStepGetFields, false)
+		if delErr := client.DeleteProject(newProject.ID); delErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback DeleteProject(%s) failed: %v\n", newProject.ID, delErr)
+		}
 		fmt.Fprintf(os.Stderr, "error: failed to load defaults: %v\n", err)
 		return fmt.Errorf("failed to load embedded defaults: %w", err)
 	}
 
-	// Fetch fields from the NEW project
-	projectFields, err := client.GetProjectFields(newProject.ID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: could not fetch project fields: %v\n", err)
-		return fmt.Errorf("could not fetch project fields: %w", err)
-	}
-
-	// Check and create required fields (IDPF only)
-	if framework == "IDPF" {
-		// Validate required fields exist with expected options
-		for _, reqField := range defs.Fields.Required {
-			field := findFieldByName(projectFields, reqField.Name)
-			if field == nil {
-				fmt.Fprintf(os.Stderr, "error: required field %q not found in project\n", reqField.Name)
-				return fmt.Errorf("required field %q not found in project", reqField.Name)
-			}
-
-			// Validate field type
-			if field.DataType != reqField.Type {
-				fmt.Fprintf(os.Stderr, "error: field %q has type %s, expected %s\n", reqField.Name, field.DataType, reqField.Type)
-				return fmt.Errorf("field %q has type %s, expected %s", reqField.Name, field.DataType, reqField.Type)
-			}
-
-			// Validate options for SINGLE_SELECT fields
-			if reqField.Type == "SINGLE_SELECT" && len(reqField.Options) > 0 {
-				for _, reqOpt := range reqField.Options {
-					found := false
-					for _, opt := range field.Options {
-						if opt.Name == reqOpt {
-							found = true
-							break
-						}
-					}
-					if !found {
-						fmt.Fprintf(os.Stderr, "error: field %q missing required option %q\n", reqField.Name, reqOpt)
-						return fmt.Errorf("field %q missing required option %q", reqField.Name, reqOpt)
-					}
-				}
-			}
-		}
-
-		// Create optional fields if missing
-		ensureOptionalProjectFields(client, newProject.ID, defs.Fields.CreateIfMissing, cmd.ErrOrStderr())
-
-		// Check and create required labels
-		for _, labelDef := range defs.Labels {
-			exists, err := client.LabelExists(repoOwner, repoName, labelDef.Name)
-			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to check label %q: %v\n", labelDef.Name, err)
-				continue
-			}
-			if !exists {
-				if err := client.CreateLabel(repoOwner, repoName, labelDef.Name, labelDef.Color, labelDef.Description); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to create label %q: %v\n", labelDef.Name, err)
-				}
-			}
-		}
-	}
-
-	// Refetch fields after potential creation
-	fields, err := client.GetProjectFields(newProject.ID)
-	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to refetch project fields: %v\n", err)
-	}
-
-	// Convert to metadata
-	metadata := &ProjectMetadata{
-		ProjectID: newProject.ID,
-	}
-	for _, f := range fields {
-		fm := FieldMetadata{
-			ID:       f.ID,
-			Name:     f.Name,
-			DataType: f.DataType,
-		}
-		for _, opt := range f.Options {
-			fm.Options = append(fm.Options, OptionMetadata{
-				ID:   opt.ID,
-				Name: opt.Name,
-			})
-		}
-		metadata.Fields = append(metadata.Fields, fm)
-	}
-
-	// Create config with NEW project number (not the source)
 	cfg := &InitConfig{
 		ProjectName:   newProject.Title,
 		ProjectOwner:  owner,
@@ -292,11 +214,19 @@ func runInitNonInteractive(cmd *cobra.Command, opts *initOptions) error {
 		Framework:     framework,
 	}
 
-	// Write config
 	cwd, _ := os.Getwd()
-	if err := writeConfigWithMetadata(cwd, cfg, metadata); err != nil {
-		fmt.Fprintf(os.Stderr, "error: failed to write config: %v\n", err)
-		return fmt.Errorf("failed to write config: %w", err)
+	if err := runInitPostCreate(client, &initPostCreateInputs{
+		Cwd:        cwd,
+		RepoOwner:  repoOwner,
+		RepoName:   repoName,
+		Framework:  framework,
+		NewProject: newProject,
+		Cfg:        cfg,
+		Defs:       defs,
+		ErrOut:     cmd.ErrOrStderr(),
+	}); err != nil {
+		// Trailer + rollback already emitted by runInitPostCreate.
+		return err
 	}
 
 	// Output success to stdout (minimal for CI/CD parsing)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,6 +48,7 @@ type initOptions struct {
 	owner          string
 	framework      string
 	yes            bool
+	force          bool
 }
 
 func newInitCommand() *cobra.Command {
@@ -75,6 +76,7 @@ Flags --project and --source-project are mutually exclusive.`,
 	cmd.Flags().StringVar(&opts.owner, "owner", "", "Project owner (defaults to repo owner)")
 	cmd.Flags().StringVar(&opts.framework, "framework", "IDPF", "Framework type (IDPF or none)")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Auto-confirm prompts")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Allow --source-project to replace an existing project pointer in .gh-pmu.json (otherwise refused; prefer --project <existing>)")
 	cmd.MarkFlagsMutuallyExclusive("project", "source-project")
 
 	return cmd
@@ -127,14 +129,22 @@ func runInitNonInteractive(cmd *cobra.Command, opts *initOptions) error {
 
 	// Check if config already exists
 	var existingFramework string
+	var existingProjectNumber int
 	if _, err := os.Stat(".gh-pmu.json"); err == nil {
-		if existingCfg, err := loadExistingFramework("."); err == nil {
-			existingFramework = existingCfg
+		if existingRaw, err := loadExistingRaw("."); err == nil {
+			existingFramework = existingRaw.Framework
+			existingProjectNumber = existingRaw.Project.Number
 		}
 		if !opts.yes {
 			fmt.Fprintf(os.Stderr, "error: .gh-pmu.json already exists (use --yes to overwrite)\n")
 			return fmt.Errorf("config already exists")
 		}
+	}
+
+	// Stricter guard: --source-project + existing project pointer requires --force
+	if err := sourceProjectGuard(existingProjectNumber, opts.sourceProject, opts.force); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return err
 	}
 
 	// Preserve existing framework on re-init
@@ -460,26 +470,56 @@ func runInitExistingProject(cmd *cobra.Command, opts *initOptions) error {
 	return nil
 }
 
-// existingConfigRaw is used for JSON unmarshaling to get framework
+// existingConfigRaw is used for JSON unmarshaling to get framework + project number
 type existingConfigRaw struct {
 	Framework string `json:"framework"`
+	Project   struct {
+		Number int `json:"number"`
+	} `json:"project"`
+}
+
+// sourceProjectGuard refuses --source-project when the repo already has a
+// .gh-pmu.json declaring a project number, unless --force is passed. Steers
+// the user toward the safer --project <existing> re-link path. Returns nil
+// when there is nothing to guard (no existing project, --source-project not
+// used, or --force present).
+func sourceProjectGuard(existingProjectNumber, sourceProject int, force bool) error {
+	if sourceProject == 0 || existingProjectNumber == 0 || force {
+		return nil
+	}
+	return fmt.Errorf(
+		".gh-pmu.json already declares project #%d. Refusing to replace it via --source-project.\n"+
+			"  To re-link to the existing project: gh pmu init --project %d --repo <owner>/<repo>\n"+
+			"  To intentionally replace it:        rerun with --force",
+		existingProjectNumber, existingProjectNumber,
+	)
 }
 
 // loadExistingFramework loads framework from existing config
 func loadExistingFramework(dir string) (string, error) {
-	configPath, err := config.FindConfigFile(dir)
+	raw, err := loadExistingRaw(dir)
 	if err != nil {
-		return "", err
-	}
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return "", err
-	}
-	var raw existingConfigRaw
-	if err := json.Unmarshal(data, &raw); err != nil {
 		return "", err
 	}
 	return raw.Framework, nil
+}
+
+// loadExistingRaw reads the existing .gh-pmu.json (if present) and returns
+// the fields needed for re-init guards: framework and current project number.
+func loadExistingRaw(dir string) (*existingConfigRaw, error) {
+	configPath, err := config.FindConfigFile(dir)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var raw existingConfigRaw
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	return &raw, nil
 }
 
 // splitRepository splits "owner/repo" into owner and repo parts.

--- a/cmd/init_atomic.go
+++ b/cmd/init_atomic.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/rubrical-works/gh-pmu/internal/api"
+	"github.com/rubrical-works/gh-pmu/internal/defaults"
+)
+
+// initPostCreateClient is the API surface runInitPostCreate touches. Kept
+// minimal so the atomicity flow is unit-testable with a fake.
+type initPostCreateClient interface {
+	GetProjectFields(projectID string) ([]api.ProjectField, error)
+	LabelExists(owner, repo, name string) (bool, error)
+	CreateLabel(owner, repo, name, color, description string) error
+	DeleteProject(projectID string) error
+	FieldExists(projectID, name string) (bool, error)
+	CreateProjectField(projectID, name, dataType string, singleSelectOptions []string) (*api.ProjectField, error)
+}
+
+// initPostCreateInputs bundles the data runInitPostCreate needs after the
+// destination project has been created. Keeps the function signature small
+// and the test setup readable.
+type initPostCreateInputs struct {
+	Cwd        string
+	RepoOwner  string
+	RepoName   string
+	Framework  string
+	NewProject *api.Project
+	Cfg        *InitConfig
+	Defs       *defaults.Defaults
+	ErrOut     io.Writer
+}
+
+// runInitPostCreate performs the post-CopyProjectFromTemplate steps inside an
+// atomicity boundary: any hard failure rolls back the just-created project
+// (via client.DeleteProject) and emits the structured failure trailer. The
+// label loop is warn+continue per #847 AC5 and never triggers rollback.
+//
+// configRewritten in the trailer is true only if writeConfigWithMetadata was
+// attempted — the file may be partially written on Windows even on error.
+func runInitPostCreate(client initPostCreateClient, in *initPostCreateInputs) error {
+	rollback := func(step string, cause error, configRewritten bool) error {
+		printInitFailureTrailer(in.ErrOut, in.NewProject.Number, step, configRewritten)
+		if delErr := client.DeleteProject(in.NewProject.ID); delErr != nil {
+			fmt.Fprintf(in.ErrOut, "warning: rollback DeleteProject(%s) failed: %v\n", in.NewProject.ID, delErr)
+		}
+		return cause
+	}
+
+	projectFields, err := client.GetProjectFields(in.NewProject.ID)
+	if err != nil {
+		return rollback(FailedStepGetFields, fmt.Errorf("could not fetch project fields: %w", err), false)
+	}
+
+	if in.Framework == "IDPF" {
+		for _, reqField := range in.Defs.Fields.Required {
+			field := findFieldByName(projectFields, reqField.Name)
+			if field == nil {
+				return rollback(FailedStepValidateRequiredFields, fmt.Errorf("required field %q not found in project", reqField.Name), false)
+			}
+			if field.DataType != reqField.Type {
+				return rollback(FailedStepValidateRequiredFields, fmt.Errorf("field %q has type %s, expected %s", reqField.Name, field.DataType, reqField.Type), false)
+			}
+			if reqField.Type == "SINGLE_SELECT" && len(reqField.Options) > 0 {
+				for _, reqOpt := range reqField.Options {
+					found := false
+					for _, opt := range field.Options {
+						if opt.Name == reqOpt {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return rollback(FailedStepValidateRequiredFields, fmt.Errorf("field %q missing required option %q", reqField.Name, reqOpt), false)
+					}
+				}
+			}
+		}
+
+		ensureOptionalProjectFields(client, in.NewProject.ID, in.Defs.Fields.CreateIfMissing, in.ErrOut)
+
+		// Label loop — warn+continue (AC5 of #847). Never rolls back.
+		for _, labelDef := range in.Defs.Labels {
+			exists, err := client.LabelExists(in.RepoOwner, in.RepoName, labelDef.Name)
+			if err != nil {
+				fmt.Fprintf(in.ErrOut, "Warning: failed to check label %q: %v\n", labelDef.Name, err)
+				continue
+			}
+			if !exists {
+				if err := client.CreateLabel(in.RepoOwner, in.RepoName, labelDef.Name, labelDef.Color, labelDef.Description); err != nil {
+					fmt.Fprintf(in.ErrOut, "Warning: failed to create label %q: %v\n", labelDef.Name, err)
+				}
+			}
+		}
+	}
+
+	// Refetch — warn+continue today (metadata may be stale but config still writable).
+	fields, err := client.GetProjectFields(in.NewProject.ID)
+	if err != nil {
+		fmt.Fprintf(in.ErrOut, "Warning: failed to refetch project fields: %v\n", err)
+	}
+
+	metadata := &ProjectMetadata{ProjectID: in.NewProject.ID}
+	for _, f := range fields {
+		fm := FieldMetadata{ID: f.ID, Name: f.Name, DataType: f.DataType}
+		for _, opt := range f.Options {
+			fm.Options = append(fm.Options, OptionMetadata{ID: opt.ID, Name: opt.Name})
+		}
+		metadata.Fields = append(metadata.Fields, fm)
+	}
+
+	if err := writeConfigWithMetadata(in.Cwd, in.Cfg, metadata); err != nil {
+		// File may be partially written on error — flag configRewritten=true defensively.
+		return rollback(FailedStepWriteConfig, fmt.Errorf("failed to write config: %w", err), true)
+	}
+
+	return nil
+}

--- a/cmd/init_failure.go
+++ b/cmd/init_failure.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+)
+
+// FailedStep names the init step that hard-failed. Emitted in the structured
+// failure trailer so callers (e.g., px-manager) can surface accurate recovery
+// UX without screen-scraping. label-setup is intentionally excluded — that
+// loop is warn+continue per AC5 of #847 and never reaches the trailer.
+const (
+	FailedStepCreateProject          = "create-project"
+	FailedStepGetFields              = "get-fields"
+	FailedStepValidateRequiredFields = "validate-required-fields"
+	FailedStepRefetchFields          = "refetch-fields"
+	FailedStepWriteConfig            = "write-config"
+	FailedStepSourceCopy             = "source-copy"
+)
+
+// AllFailedSteps is the closed enum of values printInitFailureTrailer may emit
+// for failedStep. Tests pin this set to keep the contract stable for callers.
+var AllFailedSteps = []string{
+	FailedStepCreateProject,
+	FailedStepGetFields,
+	FailedStepValidateRequiredFields,
+	FailedStepRefetchFields,
+	FailedStepWriteConfig,
+	FailedStepSourceCopy,
+}
+
+// printInitFailureTrailer writes a structured machine-readable summary of an
+// init failure. Format is labeled key=value lines on the supplied writer
+// (typically stderr). projectNumber == 0 renders as "none" to disambiguate
+// "no project created yet" from "project #0".
+func printInitFailureTrailer(w io.Writer, projectNumber int, failedStep string, configRewritten bool) {
+	projectField := "none"
+	if projectNumber > 0 {
+		projectField = fmt.Sprintf("%d", projectNumber)
+	}
+	fmt.Fprintln(w, "gh-pmu init failed:")
+	fmt.Fprintf(w, "  destinationProjectNumber=%s\n", projectField)
+	fmt.Fprintf(w, "  failedStep=%s\n", failedStep)
+	fmt.Fprintf(w, "  configRewritten=%t\n", configRewritten)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2228,3 +2228,76 @@ func TestEnsureOptionalProjectFields_CreateFieldError_LogsWarningAndContinues(t 
 		t.Errorf("expected Branch to still be created after Priority CreateProjectField error, got: %+v", mock.createCalls)
 	}
 }
+
+// ============================================================================
+// AC4 — --source-project guard tests (#847)
+// ============================================================================
+
+func TestSourceProjectGuard_AllowsWhenNoExistingConfig(t *testing.T) {
+	if err := sourceProjectGuard(0, 30, false); err != nil {
+		t.Errorf("Expected nil (no existing project), got: %v", err)
+	}
+}
+
+func TestSourceProjectGuard_AllowsWhenForcePresent(t *testing.T) {
+	if err := sourceProjectGuard(46, 30, true); err != nil {
+		t.Errorf("Expected nil with --force, got: %v", err)
+	}
+}
+
+func TestSourceProjectGuard_RefusesWhenExistingProjectAndNoForce(t *testing.T) {
+	err := sourceProjectGuard(46, 30, false)
+	if err == nil {
+		t.Fatal("Expected error when existing project + --source-project + no --force")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--project") {
+		t.Errorf("Expected error to recommend --project, got: %v", err)
+	}
+	if !strings.Contains(msg, "--force") {
+		t.Errorf("Expected error to mention --force override, got: %v", err)
+	}
+}
+
+func TestSourceProjectGuard_AllowsWhenSourceProjectZero(t *testing.T) {
+	// Caller didn't pass --source-project; nothing to guard.
+	if err := sourceProjectGuard(46, 0, false); err != nil {
+		t.Errorf("Expected nil when sourceProject == 0, got: %v", err)
+	}
+}
+
+func TestInitNonInteractive_SourceProjectGuard_RefusesWithoutForce(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Existing config declares project #46
+	configPath := filepath.Join(tmpDir, ".gh-pmu.json")
+	body := `{"version":"1.4.6","project":{"owner":"test","number":46},"repositories":["test/repo"],"framework":"IDPF","defaults":{"priority":"p2","status":"backlog"},"fields":{}}`
+	if err := os.WriteFile(configPath, []byte(body), 0644); err != nil {
+		t.Fatalf("Failed to write existing config: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"init", "--source-project", "30", "--repo", "owner/repo", "-y"})
+
+	out := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(errBuf)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Expected refusal when existing project + --source-project + no --force")
+	}
+	msg := errBuf.String()
+	if !strings.Contains(msg, "already declares project #46") {
+		t.Errorf("Expected guard message to name existing project #46, got: %s", msg)
+	}
+	if !strings.Contains(msg, "--force") {
+		t.Errorf("Expected guard message to suggest --force, got: %s", msg)
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2301,3 +2301,67 @@ func TestInitNonInteractive_SourceProjectGuard_RefusesWithoutForce(t *testing.T)
 		t.Errorf("Expected guard message to suggest --force, got: %s", msg)
 	}
 }
+
+// ============================================================================
+// AC3 — Structured failure trailer tests (#847)
+// ============================================================================
+
+func TestPrintInitFailureTrailer_AllFields(t *testing.T) {
+	var buf bytes.Buffer
+	printInitFailureTrailer(&buf, 176, FailedStepGetFields, false)
+	out := buf.String()
+	if !strings.Contains(out, "destinationProjectNumber=176") {
+		t.Errorf("Expected destinationProjectNumber=176 in output, got: %s", out)
+	}
+	if !strings.Contains(out, "failedStep=get-fields") {
+		t.Errorf("Expected failedStep=get-fields, got: %s", out)
+	}
+	if !strings.Contains(out, "configRewritten=false") {
+		t.Errorf("Expected configRewritten=false, got: %s", out)
+	}
+}
+
+func TestPrintInitFailureTrailer_NoProjectCreated(t *testing.T) {
+	// projectNumber=0 means project was never created (failure before/at create-project).
+	// Render explicitly as 'none' rather than "0" to avoid ambiguity.
+	var buf bytes.Buffer
+	printInitFailureTrailer(&buf, 0, FailedStepCreateProject, false)
+	out := buf.String()
+	if !strings.Contains(out, "destinationProjectNumber=none") {
+		t.Errorf("Expected destinationProjectNumber=none for projectNumber=0, got: %s", out)
+	}
+	if !strings.Contains(out, "failedStep=create-project") {
+		t.Errorf("Expected failedStep=create-project, got: %s", out)
+	}
+}
+
+func TestPrintInitFailureTrailer_ConfigWritten(t *testing.T) {
+	var buf bytes.Buffer
+	printInitFailureTrailer(&buf, 176, FailedStepWriteConfig, true)
+	out := buf.String()
+	if !strings.Contains(out, "configRewritten=true") {
+		t.Errorf("Expected configRewritten=true, got: %s", out)
+	}
+}
+
+func TestFailedStep_EnumStability(t *testing.T) {
+	// AC5 decision (#847): label-setup is warn+continue, NOT a hard-fail step.
+	// Enum must NOT include label-setup; if it ever does, the trailer contract
+	// becomes inconsistent with the documented label-loop posture.
+	allowed := map[string]bool{
+		"create-project":           true,
+		"get-fields":               true,
+		"validate-required-fields": true,
+		"refetch-fields":           true,
+		"write-config":             true,
+		"source-copy":              true,
+	}
+	for _, step := range AllFailedSteps {
+		if !allowed[step] {
+			t.Errorf("Unexpected failedStep value %q — keep enum aligned with #847 AC5 (label-setup excluded)", step)
+		}
+	}
+	if _, ok := allowed["label-setup"]; ok {
+		t.Fatal("Test fixture wrong: label-setup must not be allowed")
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2365,3 +2365,170 @@ func TestFailedStep_EnumStability(t *testing.T) {
 		t.Fatal("Test fixture wrong: label-setup must not be allowed")
 	}
 }
+
+// ============================================================================
+// AC2 — Atomicity tests (#847)
+// ============================================================================
+
+// fakeInitClient is a test double for initPostCreateClient. Each method's
+// behavior is configurable via callbacks so individual tests can simulate
+// failures at specific steps.
+type fakeInitClient struct {
+	getFieldsErr     error
+	getFieldsResult  []api.ProjectField
+	refetchFieldsErr error
+	refetchResult    []api.ProjectField
+	getFieldsCalls   int
+
+	labelExistsErr  error
+	createLabelErr  error
+	fieldExistsErr  error
+	createFieldErr  error
+
+	deleteProjectErr   error
+	deleteProjectCalls []string
+}
+
+func (f *fakeInitClient) GetProjectFields(projectID string) ([]api.ProjectField, error) {
+	f.getFieldsCalls++
+	if f.getFieldsCalls == 1 {
+		return f.getFieldsResult, f.getFieldsErr
+	}
+	if f.refetchFieldsErr != nil {
+		return nil, f.refetchFieldsErr
+	}
+	if f.refetchResult != nil {
+		return f.refetchResult, nil
+	}
+	return f.getFieldsResult, nil
+}
+func (f *fakeInitClient) LabelExists(o, r, n string) (bool, error) { return true, f.labelExistsErr }
+func (f *fakeInitClient) CreateLabel(o, r, n, c, d string) error  { return f.createLabelErr }
+func (f *fakeInitClient) FieldExists(p, n string) (bool, error)   { return true, f.fieldExistsErr }
+func (f *fakeInitClient) CreateProjectField(p, n, dt string, opts []string) (*api.ProjectField, error) {
+	return nil, f.createFieldErr
+}
+func (f *fakeInitClient) DeleteProject(projectID string) error {
+	f.deleteProjectCalls = append(f.deleteProjectCalls, projectID)
+	return f.deleteProjectErr
+}
+
+func newAtomicityInputs(t *testing.T, errOut *bytes.Buffer) *initPostCreateInputs {
+	t.Helper()
+	tmpDir := t.TempDir()
+	return &initPostCreateInputs{
+		Cwd:       tmpDir,
+		RepoOwner: "owner",
+		RepoName:  "repo",
+		Framework: "none", // skip required-field validation for clean defer test
+		NewProject: &api.Project{
+			ID:     "PVT_new123",
+			Number: 176,
+			Title:  "test-repo",
+		},
+		Cfg: &InitConfig{
+			ProjectName:   "test-repo",
+			ProjectOwner:  "owner",
+			ProjectNumber: 176,
+			Repositories:  []string{"owner/repo"},
+			Framework:     "none",
+		},
+		Defs:   &defaults.Defaults{},
+		ErrOut: errOut,
+	}
+}
+
+func TestRunInitPostCreate_GetFieldsFailure_RollsBackProject(t *testing.T) {
+	errBuf := &bytes.Buffer{}
+	client := &fakeInitClient{getFieldsErr: fmt.Errorf("non-200 OK status code: 504")}
+	in := newAtomicityInputs(t, errBuf)
+
+	err := runInitPostCreate(client, in)
+	if err == nil {
+		t.Fatal("Expected error from runInitPostCreate")
+	}
+
+	// Rollback: DeleteProject called with the just-created project's ID.
+	if len(client.deleteProjectCalls) != 1 || client.deleteProjectCalls[0] != "PVT_new123" {
+		t.Errorf("Expected DeleteProject('PVT_new123'), got: %v", client.deleteProjectCalls)
+	}
+
+	// Trailer: failedStep + projectNumber + configRewritten=false (config never reached).
+	out := errBuf.String()
+	if !strings.Contains(out, "failedStep=get-fields") {
+		t.Errorf("Expected trailer failedStep=get-fields, got: %s", out)
+	}
+	if !strings.Contains(out, "destinationProjectNumber=176") {
+		t.Errorf("Expected destinationProjectNumber=176, got: %s", out)
+	}
+	if !strings.Contains(out, "configRewritten=false") {
+		t.Errorf("Expected configRewritten=false (config write never attempted), got: %s", out)
+	}
+
+	// Defer: .gh-pmu.json must NOT exist in cwd.
+	if _, err := os.Stat(filepath.Join(in.Cwd, ".gh-pmu.json")); err == nil {
+		t.Error("Expected .gh-pmu.json NOT to exist after pre-config-write failure (defer variant)")
+	}
+}
+
+func TestRunInitPostCreate_RollbackErrorDoesNotMaskOriginal(t *testing.T) {
+	errBuf := &bytes.Buffer{}
+	client := &fakeInitClient{
+		getFieldsErr:     fmt.Errorf("non-200 OK status code: 504"),
+		deleteProjectErr: fmt.Errorf("rollback also failed"),
+	}
+	in := newAtomicityInputs(t, errBuf)
+
+	err := runInitPostCreate(client, in)
+	if err == nil {
+		t.Fatal("Expected original error preserved")
+	}
+	if !strings.Contains(err.Error(), "could not fetch project fields") {
+		t.Errorf("Expected original 'could not fetch project fields' error, got: %v", err)
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "warning: rollback DeleteProject(PVT_new123) failed") {
+		t.Errorf("Expected rollback-failure warning, got: %s", out)
+	}
+}
+
+func TestRunInitPostCreate_LabelLoopFailure_DoesNotRollBack(t *testing.T) {
+	// AC5: label-loop is warn+continue. Must NOT trigger rollback.
+	errBuf := &bytes.Buffer{}
+	client := &fakeInitClient{
+		labelExistsErr: fmt.Errorf("transient label-check failure"),
+	}
+	in := newAtomicityInputs(t, errBuf)
+	in.Framework = "IDPF"
+	in.Defs = &defaults.Defaults{
+		Labels: []defaults.LabelDef{{Name: "active", Color: "0e8a16"}},
+	}
+
+	err := runInitPostCreate(client, in)
+	if err != nil {
+		t.Fatalf("Expected nil (label failure is warn+continue), got: %v", err)
+	}
+	if len(client.deleteProjectCalls) != 0 {
+		t.Errorf("Expected zero DeleteProject calls (warn+continue), got: %v", client.deleteProjectCalls)
+	}
+	out := errBuf.String()
+	if !strings.Contains(out, "Warning: failed to check label") {
+		t.Errorf("Expected warning to be emitted for label failure, got: %s", out)
+	}
+}
+
+func TestRunInitPostCreate_Success_NoRollback(t *testing.T) {
+	errBuf := &bytes.Buffer{}
+	client := &fakeInitClient{}
+	in := newAtomicityInputs(t, errBuf)
+
+	if err := runInitPostCreate(client, in); err != nil {
+		t.Fatalf("Expected success, got: %v", err)
+	}
+	if len(client.deleteProjectCalls) != 0 {
+		t.Errorf("Expected zero DeleteProject calls on success, got: %v", client.deleteProjectCalls)
+	}
+	if _, err := os.Stat(filepath.Join(in.Cwd, ".gh-pmu.json")); err != nil {
+		t.Errorf("Expected .gh-pmu.json to exist after successful init: %v", err)
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2380,10 +2380,10 @@ type fakeInitClient struct {
 	refetchResult    []api.ProjectField
 	getFieldsCalls   int
 
-	labelExistsErr  error
-	createLabelErr  error
-	fieldExistsErr  error
-	createFieldErr  error
+	labelExistsErr error
+	createLabelErr error
+	fieldExistsErr error
+	createFieldErr error
 
 	deleteProjectErr   error
 	deleteProjectCalls []string
@@ -2403,8 +2403,8 @@ func (f *fakeInitClient) GetProjectFields(projectID string) ([]api.ProjectField,
 	return f.getFieldsResult, nil
 }
 func (f *fakeInitClient) LabelExists(o, r, n string) (bool, error) { return true, f.labelExistsErr }
-func (f *fakeInitClient) CreateLabel(o, r, n, c, d string) error  { return f.createLabelErr }
-func (f *fakeInitClient) FieldExists(p, n string) (bool, error)   { return true, f.fieldExistsErr }
+func (f *fakeInitClient) CreateLabel(o, r, n, c, d string) error   { return f.createLabelErr }
+func (f *fakeInitClient) FieldExists(p, n string) (bool, error)    { return true, f.fieldExistsErr }
 func (f *fakeInitClient) CreateProjectField(p, n, dt string, opts []string) (*api.ProjectField, error) {
 	return nil, f.createFieldErr
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -225,10 +225,26 @@ func (h *httpRawGraphQL) DoRawBody(body []byte, headers map[string]string) ([]by
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GraphQL request returned status %d: %s", resp.StatusCode, string(data))
+		return nil, &rawHTTPError{statusCode: resp.StatusCode, body: string(data)}
 	}
 
 	return data, nil
+}
+
+// rawHTTPError surfaces the upstream status code through the httpStatusCoder
+// interface so IsRetryable / IsTransient5xx can classify failures from the
+// raw GraphQL path the same way as typed go-gh errors.
+type rawHTTPError struct {
+	statusCode int
+	body       string
+}
+
+func (e *rawHTTPError) Error() string {
+	return fmt.Sprintf("GraphQL request returned status %d: %s", e.statusCode, e.body)
+}
+
+func (e *rawHTTPError) HTTPStatusCode() int {
+	return e.statusCode
 }
 
 // joinFeatures joins feature names with commas

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -168,8 +168,8 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 	}
 
 	return &Client{
-		gql:    gql,
-		rawGQL: &httpRawGraphQL{httpClient: httpClient, host: opts.Host},
+		gql:    newRetryingGraphQL(gql, defaultClientMaxRetries, nil),
+		rawGQL: newRetryingRawGraphQL(&httpRawGraphQL{httpClient: httpClient, host: opts.Host}, defaultClientMaxRetries, nil),
 		opts:   opts,
 	}, nil
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -90,6 +90,35 @@ func IsRateLimited(err error) bool {
 		strings.Contains(msg, "RATE_LIMITED")
 }
 
+// IsTransient5xx checks if an error indicates a transient server-side failure
+// from the upstream API. Detects via the httpStatusCoder interface for the
+// canonical transient status codes: 502 Bad Gateway, 503 Service Unavailable,
+// 504 Gateway Timeout. 500 (Internal Server Error) and 501 (Not Implemented)
+// are intentionally excluded — they typically indicate a real bug rather than
+// a recoverable transient condition. 429 is handled by IsRateLimited, not here.
+func IsTransient5xx(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sc httpStatusCoder
+	if !errors.As(err, &sc) {
+		return false
+	}
+	switch sc.HTTPStatusCode() {
+	case 502, 503, 504:
+		return true
+	}
+	return false
+}
+
+// IsRetryable returns true if an error should trigger automatic retry. It
+// composes IsRateLimited (429, rate-limited 403) with IsTransient5xx
+// (502/503/504). Callers that need rate-limit-only semantics should keep
+// using IsRateLimited directly.
+func IsRetryable(err error) bool {
+	return IsRateLimited(err) || IsTransient5xx(err)
+}
+
 // GetRetryAfter extracts a Retry-After duration from an error, if available.
 // Returns 0 if no Retry-After information is present.
 func GetRetryAfter(err error) time.Duration {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -96,19 +96,29 @@ func IsRateLimited(err error) bool {
 // 504 Gateway Timeout. 500 (Internal Server Error) and 501 (Not Implemented)
 // are intentionally excluded — they typically indicate a real bug rather than
 // a recoverable transient condition. 429 is handled by IsRateLimited, not here.
+//
+// Falls back to string-pattern matching for errors that do not satisfy
+// httpStatusCoder. shurcoolGraphQL (used by go-gh's typed GraphQL client)
+// produces plain fmt.Errorf strings of the form "non-200 OK status code: 504
+// Gateway Timeout body: ..." — the string fallback recovers retryability for
+// those cases. Mirrors the existing string fallback in IsRateLimited.
 func IsTransient5xx(err error) bool {
 	if err == nil {
 		return false
 	}
 	var sc httpStatusCoder
-	if !errors.As(err, &sc) {
+	if errors.As(err, &sc) {
+		switch sc.HTTPStatusCode() {
+		case 502, 503, 504:
+			return true
+		}
 		return false
 	}
-	switch sc.HTTPStatusCode() {
-	case 502, 503, 504:
-		return true
-	}
-	return false
+	// String fallback for errors without HTTP status interface.
+	msg := err.Error()
+	return strings.Contains(msg, "non-200 OK status code: 502") ||
+		strings.Contains(msg, "non-200 OK status code: 503") ||
+		strings.Contains(msg, "non-200 OK status code: 504")
 }
 
 // IsRetryable returns true if an error should trigger automatic retry. It

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -213,6 +213,118 @@ func TestGetRetryAfter_NonHTTPError(t *testing.T) {
 	}
 }
 
+func TestIsTransient5xx_With502(t *testing.T) {
+	err := &ghHTTPError{statusCode: 502, message: "Bad Gateway"}
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for 502")
+	}
+}
+
+func TestIsTransient5xx_With503(t *testing.T) {
+	err := &ghHTTPError{statusCode: 503, message: "Service Unavailable"}
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for 503")
+	}
+}
+
+func TestIsTransient5xx_With504(t *testing.T) {
+	err := &ghHTTPError{statusCode: 504, message: "Gateway Timeout"}
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for 504")
+	}
+}
+
+func TestIsTransient5xx_With500(t *testing.T) {
+	// 500 typically signals a real bug, not a transient — do not retry.
+	err := &ghHTTPError{statusCode: 500, message: "Internal Server Error"}
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for 500")
+	}
+}
+
+func TestIsTransient5xx_With501(t *testing.T) {
+	err := &ghHTTPError{statusCode: 501, message: "Not Implemented"}
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for 501")
+	}
+}
+
+func TestIsTransient5xx_With429(t *testing.T) {
+	// 429 is rate-limit, distinct classifier domain.
+	err := &ghHTTPError{statusCode: 429, message: "Too Many Requests"}
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for 429 (rate-limit, not transient 5xx)")
+	}
+}
+
+func TestIsTransient5xx_WithNil(t *testing.T) {
+	if IsTransient5xx(nil) {
+		t.Error("Expected IsTransient5xx to return false for nil")
+	}
+}
+
+func TestIsTransient5xx_WithNonHTTPError(t *testing.T) {
+	err := errors.New("some error without HTTPStatusCode")
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for non-HTTP error")
+	}
+}
+
+func TestIsRetryable_With429(t *testing.T) {
+	err := &ghHTTPError{statusCode: 429, message: "Too Many Requests"}
+	if !IsRetryable(err) {
+		t.Error("Expected IsRetryable to return true for 429")
+	}
+}
+
+func TestIsRetryable_With503(t *testing.T) {
+	err := &ghHTTPError{statusCode: 503, message: "Service Unavailable"}
+	if !IsRetryable(err) {
+		t.Error("Expected IsRetryable to return true for 503")
+	}
+}
+
+func TestIsRetryable_With504(t *testing.T) {
+	err := &ghHTTPError{statusCode: 504, message: "Gateway Timeout"}
+	if !IsRetryable(err) {
+		t.Error("Expected IsRetryable to return true for 504")
+	}
+}
+
+func TestIsRetryable_With403RateLimit(t *testing.T) {
+	err := &ghHTTPError{statusCode: 403, message: "API rate limit exceeded"}
+	if !IsRetryable(err) {
+		t.Error("Expected IsRetryable to return true for 403 rate-limit")
+	}
+}
+
+func TestIsRetryable_With403PermissionDenied(t *testing.T) {
+	err := &ghHTTPError{statusCode: 403, message: "Resource not accessible by integration"}
+	if IsRetryable(err) {
+		t.Error("Expected IsRetryable to return false for 403 permission denied")
+	}
+}
+
+func TestIsRetryable_With404(t *testing.T) {
+	err := &ghHTTPError{statusCode: 404, message: "Not Found"}
+	if IsRetryable(err) {
+		t.Error("Expected IsRetryable to return false for 404")
+	}
+}
+
+func TestIsRetryable_With500(t *testing.T) {
+	err := &ghHTTPError{statusCode: 500, message: "Internal Server Error"}
+	if IsRetryable(err) {
+		t.Error("Expected IsRetryable to return false for 500")
+	}
+}
+
+func TestIsRetryable_WithNil(t *testing.T) {
+	if IsRetryable(nil) {
+		t.Error("Expected IsRetryable to return false for nil")
+	}
+}
+
 // ghHTTPError simulates go-gh's api.HTTPError for testing within this package.
 // We can't import github.com/cli/go-gh/v2/pkg/api here (same package name),
 // so we use a local type and test that IsRateLimited handles the StatusCode interface.

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -270,6 +270,45 @@ func TestIsTransient5xx_WithNonHTTPError(t *testing.T) {
 	}
 }
 
+func TestIsTransient5xx_StringFallback_504(t *testing.T) {
+	// shurcoolGraphQL (under go-gh's typed GraphQL client) produces this
+	// exact format via fmt.Errorf("non-200 OK status code: %v body: %q", ...).
+	// The error does not satisfy httpStatusCoder, so the classifier must
+	// fall back to string parsing — same pattern IsRateLimited uses.
+	err := errors.New(`non-200 OK status code: 504 Gateway Timeout body: "{\"message\":\"...\"}"`)
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for shurcoolGraphQL 504 string error")
+	}
+}
+
+func TestIsTransient5xx_StringFallback_502(t *testing.T) {
+	err := errors.New(`non-200 OK status code: 502 Bad Gateway body: "..."`)
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for shurcoolGraphQL 502 string error")
+	}
+}
+
+func TestIsTransient5xx_StringFallback_503(t *testing.T) {
+	err := errors.New(`non-200 OK status code: 503 Service Unavailable body: "..."`)
+	if !IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return true for shurcoolGraphQL 503 string error")
+	}
+}
+
+func TestIsTransient5xx_StringFallback_500NotRetryable(t *testing.T) {
+	err := errors.New(`non-200 OK status code: 500 Internal Server Error body: "..."`)
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for 500 (real-bug, not transient)")
+	}
+}
+
+func TestIsTransient5xx_StringFallback_404NotRetryable(t *testing.T) {
+	err := errors.New(`non-200 OK status code: 404 Not Found body: "..."`)
+	if IsTransient5xx(err) {
+		t.Error("Expected IsTransient5xx to return false for 404")
+	}
+}
+
 func TestIsRetryable_With429(t *testing.T) {
 	err := &ghHTTPError{statusCode: 429, message: "Too Many Requests"}
 	if !IsRetryable(err) {

--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -1914,3 +1914,36 @@ func (c *Client) executeBatchMutation(projectID string, updates []FieldUpdate) (
 
 	return results, nil
 }
+
+// DeleteProjectV2Input represents the input for deleting a project.
+type DeleteProjectV2Input struct {
+	ProjectID graphql.ID `json:"projectId"`
+}
+
+// DeleteProject deletes a GitHub Projects v2 project. Used by init's atomicity
+// rollback path: when post-creation setup hard-fails, the just-created project
+// is removed so the org isn't littered with orphans.
+func (c *Client) DeleteProject(projectID string) error {
+	if projectID == "" {
+		return fmt.Errorf("project ID is required")
+	}
+
+	var mutation struct {
+		DeleteProjectV2 struct {
+			ClientMutationID string `graphql:"clientMutationId"`
+		} `graphql:"deleteProjectV2(input: $input)"`
+	}
+
+	input := DeleteProjectV2Input{
+		ProjectID: graphql.ID(projectID),
+	}
+
+	variables := map[string]interface{}{
+		"input": input,
+	}
+
+	if err := c.gql.Mutate("DeleteProjectV2", &mutation, variables); err != nil {
+		return fmt.Errorf("failed to delete project: %w", err)
+	}
+	return nil
+}

--- a/internal/api/mutations_test.go
+++ b/internal/api/mutations_test.go
@@ -3102,3 +3102,63 @@ func TestLinkProjectToRepository_MutationError(t *testing.T) {
 		t.Errorf("Expected 'failed to link repository to project' in error, got: %v", err)
 	}
 }
+
+// ============================================================================
+// DeleteProject Tests
+// ============================================================================
+
+func TestDeleteProject_Success(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			if name != "DeleteProjectV2" {
+				t.Errorf("Expected mutation name 'DeleteProjectV2', got '%s'", name)
+			}
+			return nil
+		},
+	}
+	client := NewClientWithGraphQL(mock)
+	if err := client.DeleteProject("PVT_abc"); err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+}
+
+func TestDeleteProject_EmptyProjectID(t *testing.T) {
+	client := NewClientWithGraphQL(&mockGraphQLClient{})
+	err := client.DeleteProject("")
+	if err == nil {
+		t.Fatal("Expected error for empty project ID, got nil")
+	}
+}
+
+func TestDeleteProject_MutationError(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			return errors.New("project not found")
+		},
+	}
+	client := NewClientWithGraphQL(mock)
+	err := client.DeleteProject("PVT_missing")
+	if err == nil {
+		t.Fatal("Expected error when mutation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to delete project") {
+		t.Errorf("Expected wrapper 'failed to delete project', got: %v", err)
+	}
+}
+
+func TestDeleteProject_InputVariables(t *testing.T) {
+	mock := &mockGraphQLClient{
+		mutateFunc: func(name string, mutation interface{}, variables map[string]interface{}) error {
+			input, ok := variables["input"].(DeleteProjectV2Input)
+			if !ok {
+				t.Fatal("Expected input to be DeleteProjectV2Input type")
+			}
+			if input.ProjectID != "PVT_xyz" {
+				t.Errorf("Expected ProjectID 'PVT_xyz', got '%s'", input.ProjectID)
+			}
+			return nil
+		},
+	}
+	client := NewClientWithGraphQL(mock)
+	_ = client.DeleteProject("PVT_xyz")
+}

--- a/internal/api/retry.go
+++ b/internal/api/retry.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"time"
 )
@@ -14,34 +15,54 @@ var DefaultRetryDelays = []time.Duration{
 	8 * time.Second,
 }
 
-// WithRetry executes a function with automatic retry on rate limit errors.
-// Uses exponential backoff: 1s, 2s, 4s, 8s delays.
-// Returns the function's error if not rate limited, or after max retries exceeded.
+// WithRetry executes a function with automatic retry on retryable errors.
+// Retryable errors are rate limits (429, rate-limited 403) and transient
+// 5xx responses (502/503/504); see IsRetryable. Uses exponential backoff
+// with positive jitter to avoid thundering herd on coordinated retries.
+// Returns the function's error if not retryable, or after max retries exceeded.
 func WithRetry(fn func() error, maxRetries int) error {
 	return WithRetryDelays(fn, maxRetries, DefaultRetryDelays)
 }
 
 // WithRetryDelays executes a function with automatic retry using custom delays.
 // This variant is primarily for testing to allow faster tests.
-// If the error carries a Retry-After header, that value overrides the default delay.
+// If the error carries a Retry-After header, that value overrides the default
+// delay (and is not jittered — server-mandated delay is honored exactly).
 func WithRetryDelays(fn func() error, maxRetries int, delays []time.Duration) error {
 	var err error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		err = fn()
-		if err == nil || !IsRateLimited(err) {
+		if err == nil || !IsRetryable(err) {
 			return err
 		}
 		if attempt < maxRetries {
 			delay := delays[min(attempt, len(delays)-1)]
-			// Retry-After header overrides default delay
+			// Retry-After header overrides default delay (no jitter on server-mandated delay)
 			if retryAfter := GetRetryAfter(err); retryAfter > 0 {
 				delay = retryAfter
+			} else {
+				delay = applyJitter(delay)
 			}
-			fmt.Fprintf(os.Stderr, "Warning: rate limited, retrying in %v...\n", delay)
+			reason := "transient error"
+			if IsRateLimited(err) {
+				reason = "rate limited"
+			}
+			fmt.Fprintf(os.Stderr, "Warning: %s, retrying in %v...\n", reason, delay)
 			time.Sleep(delay)
 		}
 	}
 	return err
+}
+
+// applyJitter returns a duration in [d, d*1.25]. The positive-only bias
+// preserves the configured base as a lower bound (callers never wait less
+// than they asked for) while spreading retries enough to avoid thundering
+// herd in coordinated-client scenarios. Returns 0 unchanged.
+func applyJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	return d + time.Duration(float64(d)*0.25*rand.Float64())
 }
 
 // min returns the smaller of two integers

--- a/internal/api/retry.go
+++ b/internal/api/retry.go
@@ -62,6 +62,7 @@ func applyJitter(d time.Duration) time.Duration {
 	if d <= 0 {
 		return d
 	}
+	// #nosec G404 -- jitter for retry backoff, not a security context; math/rand is appropriate.
 	return d + time.Duration(float64(d)*0.25*rand.Float64())
 }
 

--- a/internal/api/retry_client.go
+++ b/internal/api/retry_client.go
@@ -1,0 +1,70 @@
+package api
+
+import "time"
+
+// defaultClientMaxRetries is the retry budget applied to every API call routed
+// through a retrying decorator. Three attempts after the initial call.
+const defaultClientMaxRetries = 3
+
+// retryingGraphQL decorates a GraphQLClient so every Mutate / Query call is
+// transparently retried on retryable errors (rate limits + transient 5xx).
+// All gh-pmu commands inherit this without per-call-site wrapping.
+type retryingGraphQL struct {
+	inner      GraphQLClient
+	maxRetries int
+	delays     []time.Duration
+}
+
+// newRetryingGraphQL wraps inner. delays may be nil to use DefaultRetryDelays.
+func newRetryingGraphQL(inner GraphQLClient, maxRetries int, delays []time.Duration) *retryingGraphQL {
+	if delays == nil {
+		delays = DefaultRetryDelays
+	}
+	return &retryingGraphQL{inner: inner, maxRetries: maxRetries, delays: delays}
+}
+
+func (r *retryingGraphQL) Mutate(name string, mutation interface{}, vars map[string]interface{}) error {
+	return WithRetryDelays(func() error {
+		return r.inner.Mutate(name, mutation, vars)
+	}, r.maxRetries, r.delays)
+}
+
+func (r *retryingGraphQL) Query(name string, query interface{}, vars map[string]interface{}) error {
+	return WithRetryDelays(func() error {
+		return r.inner.Query(name, query, vars)
+	}, r.maxRetries, r.delays)
+}
+
+// retryingRawGraphQL is the analog for raw / typed-batch GraphQL calls.
+type retryingRawGraphQL struct {
+	inner      RawGraphQLDoer
+	maxRetries int
+	delays     []time.Duration
+}
+
+func newRetryingRawGraphQL(inner RawGraphQLDoer, maxRetries int, delays []time.Duration) *retryingRawGraphQL {
+	if delays == nil {
+		delays = DefaultRetryDelays
+	}
+	return &retryingRawGraphQL{inner: inner, maxRetries: maxRetries, delays: delays}
+}
+
+func (r *retryingRawGraphQL) DoRaw(query string, headers map[string]string) ([]byte, error) {
+	var data []byte
+	err := WithRetryDelays(func() error {
+		var inner error
+		data, inner = r.inner.DoRaw(query, headers)
+		return inner
+	}, r.maxRetries, r.delays)
+	return data, err
+}
+
+func (r *retryingRawGraphQL) DoRawBody(body []byte, headers map[string]string) ([]byte, error) {
+	var data []byte
+	err := WithRetryDelays(func() error {
+		var inner error
+		data, inner = r.inner.DoRawBody(body, headers)
+		return inner
+	}, r.maxRetries, r.delays)
+	return data, err
+}

--- a/internal/api/retry_client_test.go
+++ b/internal/api/retry_client_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeGQL records call counts and returns a sequence of errors.
+type fakeGQL struct {
+	mutateCalls int
+	queryCalls  int
+	mutateErrs  []error
+	queryErrs   []error
+}
+
+func (f *fakeGQL) Mutate(name string, mutation interface{}, vars map[string]interface{}) error {
+	defer func() { f.mutateCalls++ }()
+	if f.mutateCalls < len(f.mutateErrs) {
+		return f.mutateErrs[f.mutateCalls]
+	}
+	return nil
+}
+
+func (f *fakeGQL) Query(name string, query interface{}, vars map[string]interface{}) error {
+	defer func() { f.queryCalls++ }()
+	if f.queryCalls < len(f.queryErrs) {
+		return f.queryErrs[f.queryCalls]
+	}
+	return nil
+}
+
+func TestRetryingGraphQL_MutateRetriesOn504(t *testing.T) {
+	gw := &httpStatusError{code: 504, msg: "Gateway Timeout"}
+	inner := &fakeGQL{mutateErrs: []error{gw, gw}}
+	dec := newRetryingGraphQL(inner, 3, []time.Duration{1 * time.Millisecond})
+
+	err := dec.Mutate("op", nil, nil)
+	if err != nil {
+		t.Fatalf("Expected nil after 2 retries + success, got: %v", err)
+	}
+	if inner.mutateCalls != 3 {
+		t.Errorf("Expected 3 Mutate calls (2 504 + 1 success), got %d", inner.mutateCalls)
+	}
+}
+
+func TestRetryingGraphQL_QueryRetriesOn503(t *testing.T) {
+	un := &httpStatusError{code: 503, msg: "Service Unavailable"}
+	inner := &fakeGQL{queryErrs: []error{un}}
+	dec := newRetryingGraphQL(inner, 3, []time.Duration{1 * time.Millisecond})
+
+	err := dec.Query("op", nil, nil)
+	if err != nil {
+		t.Fatalf("Expected nil after 1 retry + success, got: %v", err)
+	}
+	if inner.queryCalls != 2 {
+		t.Errorf("Expected 2 Query calls, got %d", inner.queryCalls)
+	}
+}
+
+func TestRetryingGraphQL_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	notFound := &httpStatusError{code: 404, msg: "Not Found"}
+	inner := &fakeGQL{mutateErrs: []error{notFound}}
+	dec := newRetryingGraphQL(inner, 3, []time.Duration{1 * time.Millisecond})
+
+	err := dec.Mutate("op", nil, nil)
+	if err != notFound {
+		t.Errorf("Expected original 404 error, got: %v", err)
+	}
+	if inner.mutateCalls != 1 {
+		t.Errorf("Expected 1 Mutate call (no retry), got %d", inner.mutateCalls)
+	}
+}
+
+// fakeRaw records call counts and returns a sequence of error/payload pairs.
+type fakeRaw struct {
+	calls int
+	errs  []error
+	body  []byte
+}
+
+func (f *fakeRaw) DoRaw(query string, headers map[string]string) ([]byte, error) {
+	defer func() { f.calls++ }()
+	if f.calls < len(f.errs) {
+		return nil, f.errs[f.calls]
+	}
+	return f.body, nil
+}
+
+func (f *fakeRaw) DoRawBody(body []byte, headers map[string]string) ([]byte, error) {
+	return f.DoRaw("", headers)
+}
+
+func TestRetryingRawGraphQL_DoRawRetriesOn502(t *testing.T) {
+	bg := &httpStatusError{code: 502, msg: "Bad Gateway"}
+	inner := &fakeRaw{errs: []error{bg}, body: []byte("ok")}
+	dec := newRetryingRawGraphQL(inner, 3, []time.Duration{1 * time.Millisecond})
+
+	data, err := dec.DoRaw("query", nil)
+	if err != nil {
+		t.Fatalf("Expected nil error after retry, got: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Errorf("Expected payload 'ok', got %q", string(data))
+	}
+	if inner.calls != 2 {
+		t.Errorf("Expected 2 DoRaw calls, got %d", inner.calls)
+	}
+}
+
+func TestRetryingRawGraphQL_DoRawBodyRetriesOn504(t *testing.T) {
+	gw := &httpStatusError{code: 504, msg: "Gateway Timeout"}
+	inner := &fakeRaw{errs: []error{gw}, body: []byte("payload")}
+	dec := newRetryingRawGraphQL(inner, 3, []time.Duration{1 * time.Millisecond})
+
+	data, err := dec.DoRawBody([]byte("body"), nil)
+	if err != nil {
+		t.Fatalf("Expected nil error after retry, got: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Errorf("Expected 'payload', got %q", string(data))
+	}
+	if inner.calls != 2 {
+		t.Errorf("Expected 2 calls, got %d", inner.calls)
+	}
+}
+
+func TestNewClientWithOptions_GraphQLClientIsRetrying(t *testing.T) {
+	c, err := NewClientWithOptions(ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClientWithOptions failed: %v", err)
+	}
+	if _, ok := c.gql.(*retryingGraphQL); !ok {
+		t.Errorf("Expected c.gql to be *retryingGraphQL, got %T", c.gql)
+	}
+	if _, ok := c.rawGQL.(*retryingRawGraphQL); !ok {
+		t.Errorf("Expected c.rawGQL to be *retryingRawGraphQL, got %T", c.rawGQL)
+	}
+}

--- a/internal/api/retry_client_test.go
+++ b/internal/api/retry_client_test.go
@@ -125,7 +125,9 @@ func TestRetryingRawGraphQL_DoRawBodyRetriesOn504(t *testing.T) {
 }
 
 func TestNewClientWithOptions_GraphQLClientIsRetrying(t *testing.T) {
-	c, err := NewClientWithOptions(ClientOptions{})
+	// Provide a stub auth token so go-gh's NewGraphQLClient doesn't fail on
+	// auth-discovery in CI environments without `gh auth status`.
+	c, err := NewClientWithOptions(ClientOptions{AuthToken: "test-token"})
 	if err != nil {
 		t.Fatalf("NewClientWithOptions failed: %v", err)
 	}

--- a/internal/api/retry_integration_test.go
+++ b/internal/api/retry_integration_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"sync/atomic"
@@ -27,6 +28,7 @@ func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 func makeResp(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)), // shurcoolGraphQL embeds resp.Status (e.g. "504 Gateway Timeout") in its error message
 		Body:       io.NopCloser(bytes.NewBufferString(body)),
 		Header:     make(http.Header),
 	}
@@ -62,6 +64,49 @@ func TestRetryIntegration_RawGraphQL504ThenSuccess(t *testing.T) {
 	}
 	if string(data) != `{"data":{"ok":true}}` {
 		t.Errorf("Expected success payload, got %q", string(data))
+	}
+	if got := transport.calls.Load(); got != 2 {
+		t.Errorf("Expected exactly 2 transport calls (1 504 + 1 200), got %d", got)
+	}
+}
+
+// TestRetryIntegration_TypedGraphQL504ThenSuccess exercises the typed go-gh
+// GraphQL path end-to-end: the typed Mutate/Query route through go-gh's own
+// HTTP-error wrapping, so this test verifies our IsRetryable classifier
+// agrees with the actual error shape go-gh produces — not just our local
+// rawHTTPError fixture. Catches divergence if go-gh changes how non-200
+// responses are wrapped.
+func TestRetryIntegration_TypedGraphQL504ThenSuccess(t *testing.T) {
+	transport := &fakeRoundTripper{
+		responses: []*http.Response{
+			makeResp(504, `{"message":"Gateway Timeout"}`),
+			makeResp(200, `{"data":{"viewer":{"login":"octocat"}}}`),
+		},
+	}
+	SetTestTransport(transport)
+	defer SetTestTransport(nil)
+	SetTestAuthToken("test-token") // go-gh refuses to construct a client without one
+	defer SetTestAuthToken("")
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	// Re-wrap with millisecond delays so the test isn't slow.
+	gqlInner := c.gql.(*retryingGraphQL).inner
+	c.gql = newRetryingGraphQL(gqlInner, 3, []time.Duration{1 * time.Millisecond})
+
+	var q struct {
+		Viewer struct {
+			Login string
+		}
+	}
+	if err := c.gql.Query("Viewer", &q, nil); err != nil {
+		t.Fatalf("Expected nil error after typed-path retry recovers from 504, got: %v", err)
+	}
+	if q.Viewer.Login != "octocat" {
+		t.Errorf("Expected viewer.login 'octocat', got %q", q.Viewer.Login)
 	}
 	if got := transport.calls.Load(); got != 2 {
 		t.Errorf("Expected exactly 2 transport calls (1 504 + 1 200), got %d", got)

--- a/internal/api/retry_integration_test.go
+++ b/internal/api/retry_integration_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeRoundTripper returns canned responses in order. After the slice is
+// exhausted it returns a sentinel error to make over-call faults visible.
+type fakeRoundTripper struct {
+	calls     atomic.Int32
+	responses []*http.Response
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := int(f.calls.Add(1)) - 1
+	if idx >= len(f.responses) {
+		return nil, io.EOF
+	}
+	return f.responses[idx], nil
+}
+
+func makeResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// TestRetryIntegration_RawGraphQL504ThenSuccess verifies the end-to-end retry
+// behaviour through the raw GraphQL path: a 504 response on the first attempt
+// triggers exactly one retry, and the second 200 response is returned to the
+// caller without surfacing the 504.
+func TestRetryIntegration_RawGraphQL504ThenSuccess(t *testing.T) {
+	transport := &fakeRoundTripper{
+		responses: []*http.Response{
+			makeResp(504, `{"message":"Gateway Timeout"}`),
+			makeResp(200, `{"data":{"ok":true}}`),
+		},
+	}
+	SetTestTransport(transport)
+	defer SetTestTransport(nil)
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	// Override the raw decorator's delays so the test runs in milliseconds, not seconds.
+	// Construction wraps with DefaultRetryDelays; for testability we re-wrap here.
+	rawInner := c.rawGQL.(*retryingRawGraphQL).inner
+	c.rawGQL = newRetryingRawGraphQL(rawInner, 3, []time.Duration{1 * time.Millisecond})
+
+	data, err := c.rawGQL.DoRaw("{ ok }", nil)
+	if err != nil {
+		t.Fatalf("Expected nil error after retry recovers from 504, got: %v", err)
+	}
+	if string(data) != `{"data":{"ok":true}}` {
+		t.Errorf("Expected success payload, got %q", string(data))
+	}
+	if got := transport.calls.Load(); got != 2 {
+		t.Errorf("Expected exactly 2 transport calls (1 504 + 1 200), got %d", got)
+	}
+}
+
+// TestRetryIntegration_RawGraphQLNonRetryable surfaces the 404 immediately
+// without consuming additional retries.
+func TestRetryIntegration_RawGraphQLNonRetryable(t *testing.T) {
+	transport := &fakeRoundTripper{
+		responses: []*http.Response{
+			makeResp(404, `{"message":"Not Found"}`),
+		},
+	}
+	SetTestTransport(transport)
+	defer SetTestTransport(nil)
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	rawInner := c.rawGQL.(*retryingRawGraphQL).inner
+	c.rawGQL = newRetryingRawGraphQL(rawInner, 3, []time.Duration{1 * time.Millisecond})
+
+	_, err = c.rawGQL.DoRaw("{ q }", nil)
+	if err == nil {
+		t.Fatal("Expected error from 404, got nil")
+	}
+	if got := transport.calls.Load(); got != 1 {
+		t.Errorf("Expected 1 transport call (no retry on 404), got %d", got)
+	}
+}

--- a/internal/api/retry_integration_test.go
+++ b/internal/api/retry_integration_test.go
@@ -47,6 +47,8 @@ func TestRetryIntegration_RawGraphQL504ThenSuccess(t *testing.T) {
 	}
 	SetTestTransport(transport)
 	defer SetTestTransport(nil)
+	SetTestAuthToken("test-token") // go-gh refuses to construct a client without one (CI lacks gh auth)
+	defer SetTestAuthToken("")
 
 	c, err := NewClient()
 	if err != nil {
@@ -123,6 +125,8 @@ func TestRetryIntegration_RawGraphQLNonRetryable(t *testing.T) {
 	}
 	SetTestTransport(transport)
 	defer SetTestTransport(nil)
+	SetTestAuthToken("test-token")
+	defer SetTestAuthToken("")
 
 	c, err := NewClient()
 	if err != nil {

--- a/internal/api/retry_test.go
+++ b/internal/api/retry_test.go
@@ -205,6 +205,105 @@ func TestWithRetryDelays_MaxRetriesExhaustedClearMessage(t *testing.T) {
 	}
 }
 
+func TestWithRetryDelays_504TriggersRetry(t *testing.T) {
+	callCount := 0
+	gatewayErr := &httpStatusError{code: 504, msg: "Gateway Timeout"}
+	err := WithRetryDelays(func() error {
+		callCount++
+		if callCount < 3 {
+			return gatewayErr
+		}
+		return nil
+	}, 3, []time.Duration{1 * time.Millisecond})
+
+	if err != nil {
+		t.Errorf("Expected nil error after retry, got: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("Expected 3 calls (2 504s + 1 success), got %d", callCount)
+	}
+}
+
+func TestWithRetryDelays_502TriggersRetry(t *testing.T) {
+	callCount := 0
+	badGatewayErr := &httpStatusError{code: 502, msg: "Bad Gateway"}
+	err := WithRetryDelays(func() error {
+		callCount++
+		if callCount < 2 {
+			return badGatewayErr
+		}
+		return nil
+	}, 3, []time.Duration{1 * time.Millisecond})
+	if err != nil {
+		t.Errorf("Expected nil error after retry, got: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("Expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestWithRetryDelays_503TriggersRetry(t *testing.T) {
+	callCount := 0
+	unavailErr := &httpStatusError{code: 503, msg: "Service Unavailable"}
+	err := WithRetryDelays(func() error {
+		callCount++
+		if callCount < 2 {
+			return unavailErr
+		}
+		return nil
+	}, 3, []time.Duration{1 * time.Millisecond})
+	if err != nil {
+		t.Errorf("Expected nil error after retry, got: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("Expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestWithRetryDelays_500DoesNotRetry(t *testing.T) {
+	// 500 is not classified as transient — likely a real server-side bug.
+	callCount := 0
+	internalErr := &httpStatusError{code: 500, msg: "Internal Server Error"}
+	err := WithRetryDelays(func() error {
+		callCount++
+		return internalErr
+	}, 3, []time.Duration{1 * time.Millisecond})
+	if err != internalErr {
+		t.Errorf("Expected original 500 error, got: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("Expected 1 call (no retry for 500), got %d", callCount)
+	}
+}
+
+func TestApplyJitter_PositiveBiasRange(t *testing.T) {
+	// Positive-only jitter: result lies in [base, base*1.25]. Positive bias
+	// preserves the "delay at least the configured base" guarantee that the
+	// existing TestWithRetryDelays_UsesLastDelayWhenAttemptsExceedDelayLength
+	// test relies on, while still spreading retries to avoid thundering herd.
+	base := 100 * time.Millisecond
+	high := time.Duration(float64(base) * 1.25)
+	sawAbove := false
+	for i := 0; i < 200; i++ {
+		got := applyJitter(base)
+		if got < base || got > high {
+			t.Fatalf("applyJitter(%v) = %v, outside [%v, %v]", base, got, base, high)
+		}
+		if got > base {
+			sawAbove = true
+		}
+	}
+	if !sawAbove {
+		t.Errorf("Expected at least one jittered value strictly above base over 200 iterations; got all == base")
+	}
+}
+
+func TestApplyJitter_ZeroBaseReturnsZero(t *testing.T) {
+	if got := applyJitter(0); got != 0 {
+		t.Errorf("applyJitter(0) = %v, want 0", got)
+	}
+}
+
 // httpStatusError simulates an HTTP error with a status code for testing.
 type httpStatusError struct {
 	code int

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,4 +4,4 @@ package version
 
 // Version is the current gh-pmu version.
 // Updated by /prepare-release — do not edit manually during development.
-const Version = "1.4.8"
+const Version = "1.4.9"

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -160,24 +160,31 @@ func TestInitNonInteractiveWithOwner(t *testing.T) {
 	}
 }
 
-// TestInitNonInteractiveOverwrite tests the --yes flag for overwriting.
+// TestInitNonInteractiveOverwrite tests the --yes + --force combo for overwriting
+// when the existing config declares a project number. Since #847 added a guard
+// that refuses --source-project against a repo whose .gh-pmu.json declares a
+// project (steering users toward --project <existing>), the explicit-replace
+// path now requires --force in addition to --yes.
 func TestInitNonInteractiveOverwrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	initGitRepo(t, tmpDir)
 
-	// Create existing config
+	// Create existing config with a project number — triggers the #847 guard.
 	existingConfig := `{"project":{"name":"existing","owner":"test","number":999}}`
 	configPath := filepath.Join(tmpDir, ".gh-pmu.json")
 	if err := os.WriteFile(configPath, []byte(existingConfig), 0644); err != nil {
 		t.Fatalf("Failed to write existing config: %v", err)
 	}
 
-	// Run init with --yes to overwrite
+	// Run init with --yes + --force to overwrite (--yes alone is no longer enough
+	// when the existing config has a project number; --force confirms the user
+	// really wants to replace the project pointer rather than re-link via --project).
 	result := runPMU(t, tmpDir, "init",
 		"--non-interactive",
 		"--source-project", "41",
 		"--repo", "rubrical-works/gh-pmu-e2e-test",
 		"--yes",
+		"--force",
 	)
 
 	assertExitCode(t, result, 0)


### PR DESCRIPTION
## Summary

Release v1.4.9 — patch bump with two coordinated bug fixes that close a long-standing reliability gap in `gh pmu init`.

### Fixes

- **#849 (foundation)** — retry layer now classifies transient HTTP 5xx (502/503/504) in addition to rate limits. Decorator wraps `Client.gql` and `Client.rawGQL` at construction so every command (`init`, `edit`, `view`, etc.) inherits transparent retry without per-call-site changes. Closes a previously latent gap where typed-GraphQL errors from go-gh's underlying `shurcoolGraphQL` were silently NOT matching the rate-limit classifier (string fallback added; mirrors existing pattern in `IsRateLimited`).
- **#847 (consumer)** — `gh pmu init` is now atomic. Any post-creation failure rolls back the just-created project (no orphans on the org); `.gh-pmu.json` is only written as the final step. New `--force` flag guards against accidentally replacing an existing project pointer when `--source-project` is used. Hard failures emit a structured trailer (`destinationProjectNumber=N`, `failedStep=...`, `configRewritten=bool`) for callers like px-manager.

### Design decisions
- Defer atomicity (no `.gh-pmu.json.bak`) chosen over snapshot-and-restore. See `Construction/Design-Decisions/2026-05-05-init-atomicity-defer-with-rollback.md`.
- Label loop kept warn+continue (#849's retry handles transient 5xx; persistent label failures are config issues users fix externally).
- Retry classifier uses positive-bias jitter (delay ∈ [base, base*1.25]) to spread coordinated-client retries without violating the "wait at least the configured base" guarantee that existing tests rely on.

## Test plan

- [x] `go test ./...` — all packages green
- [x] Coverage gate: 70.8% (threshold 70%)
- [x] `golangci-lint run` — clean
- [x] E2E suite (full re-run): 20/20 passed locally (~6m)
- [x] One previously-passing E2E (`TestInitNonInteractiveOverwrite`) updated to use `--force` per the new guard — captures the intentional behavior change
- [x] Manual proxy verification — tracked in QA sub-issues (#850 retry layer, #851 init atomicity)
- [ ] CI on this PR (will run after open)

## Issues closed

- #849 — retry layer missing 5xx classification
- #847 — init non-atomic / orphan project on post-create failure

(QA sub-issues #850 and #851 remain open as manual-verification tasks.)
