### PR TITLE
fix(release): goreleaser owner rubrical-works -> rubrical-worker

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ changelog:
 
 release:
   github:
-    owner: rubrical-works
+    owner: rubrical-worker
     name: gh-pmu
   prerelease: auto
   name_template: "gh-pmu {{.Version}}"


### PR DESCRIPTION
One-line fix: GoReleaser still published to the pre-rename owner `rubrical-works`. Release creation survived via API redirect, but asset uploads to uploads.github.com got 307 redirects GoReleaser does not follow, failing the v1.5.0 release job (run 30052025835, all 7 assets).

Tag v1.5.0 will be moved to include this commit and re-pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
